### PR TITLE
Rename PyBee to BeeWare

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,8 @@
 # Contributing
 
-PyBee <3's contributions! 
+BeeWare <3's contributions!
 
-Please be aware, PyBee operates under a Code of Conduct. 
+Please be aware, BeeWare operates under a Code of Conduct.
 
-See [CONTRIBUTING to PyBee](http://pybee.org/contributing) for details.
+See [CONTRIBUTING to BeeWare](http://beeware.org/contributing) for details.
 

--- a/Makefile
+++ b/Makefile
@@ -21,24 +21,24 @@ endif
 
 all: dist/rubicon.jar dist/librubicon.$(SOEXT) dist/test.jar
 
-dist/rubicon.jar: org/pybee/rubicon/Python.class org/pybee/rubicon/PythonInstance.class
+dist/rubicon.jar: org/beeware/rubicon/Python.class org/beeware/rubicon/PythonInstance.class
 	mkdir -p dist
-	jar -cvf dist/rubicon.jar org/pybee/rubicon/Python.class org/pybee/rubicon/PythonInstance.class
+	jar -cvf dist/rubicon.jar org/beeware/rubicon/Python.class org/beeware/rubicon/PythonInstance.class
 
-dist/test.jar: org/pybee/rubicon/test/BaseExample.class org/pybee/rubicon/test/Example.class org/pybee/rubicon/test/ICallback.class org/pybee/rubicon/test/AbstractCallback.class org/pybee/rubicon/test/Thing.class org/pybee/rubicon/test/Test.class
+dist/test.jar: org/beeware/rubicon/test/BaseExample.class org/beeware/rubicon/test/Example.class org/beeware/rubicon/test/ICallback.class org/beeware/rubicon/test/AbstractCallback.class org/beeware/rubicon/test/Thing.class org/beeware/rubicon/test/Test.class
 	mkdir -p dist
-	jar -cvf dist/test.jar org/pybee/rubicon/test/*.class
+	jar -cvf dist/test.jar org/beeware/rubicon/test/*.class
 
 dist/librubicon.$(SOEXT): jni/rubicon.o
 	mkdir -p dist
 	gcc -shared -o $@ $< $(PYLDFLAGS)
 
 test: all
-	java org.pybee.rubicon.test.Test
+	java org.beeware.rubicon.test.Test
 
 clean:
-	rm -f org/pybee/rubicon/test/*.class
-	rm -f org/pybee/rubicon/*.class
+	rm -f org/beeware/rubicon/test/*.class
+	rm -f org/beeware/rubicon/*.class
 	rm -f jni/*.o
 	rm -rf dist
 

--- a/README.rst
+++ b/README.rst
@@ -15,13 +15,13 @@ Rubicon-Java
     :target: https://pypi.python.org/pypi/rubicon-java
 
 .. image:: https://img.shields.io/pypi/l/rubicon-java.svg
-    :target: https://github.com/pybee/rubicon-java/blob/master/LICENSE
+    :target: https://github.com/beeware/rubicon-java/blob/master/LICENSE
 
-.. image:: https://travis-ci.org/pybee/rubicon-java.svg?branch=master
-    :target: https://travis-ci.org/pybee/rubicon-java
+.. image:: https://travis-ci.org/beeware/rubicon-java.svg?branch=master
+    :target: https://travis-ci.org/beeware/rubicon-java
 
-.. image:: https://badges.gitter.im/pybee/general.svg
-    :target: https://gitter.im/pybee/general
+.. image:: https://badges.gitter.im/beeware/general.svg
+    :target: https://gitter.im/beeware/general
 
 Rubicon-Java is a bridge between the Java Runtime Environment and Python.
 It enables you to:
@@ -75,7 +75,7 @@ To use Rubicon-Java, you'll need to ensure:
 
 The Rubicon bridge starts on the Java side. Import the Python object::
 
-    import org.pybee.rubicon.Python;
+    import org.beeware.rubicon.Python;
 
 Then start the Python interpreter, and run a Python file::
 
@@ -106,12 +106,12 @@ In your Python script, you can then reference Java objects::
 
     # Then instantiate the Java class, using the API
     # that is exposed in Java.
-    >>> url = URL("http://pybee.org")
+    >>> url = URL("http://beeware.org")
 
     # You can then call methods on the Java object as if it
     # were a Python object.
     >>> print url.getHost()
-    pybee.org
+    beeware.org
 
 It's also possible to provide implementations of Java Interfaces in Python.
 For example, lets say you want to create a Swing Button, and you want to
@@ -157,7 +157,7 @@ To run the Rubicon test suite:
 
 3. Run the test suite::
 
-    $ java org.pybee.rubicon.test.Test
+    $ java org.beeware.rubicon.test.Test
 
 This is a Python test suite, invoked via Java.
 
@@ -171,9 +171,9 @@ Community
 
 Rubicon is part of the `BeeWare suite`_. You can talk to the community through:
 
-* `@pybeeware on Twitter`_
+* `@beewareware on Twitter`_
 
-* The `pybee/general`_ channel on Gitter.
+* The `beeware/general`_ channel on Gitter.
 
 We foster a welcoming and respectful community as described in our
 `BeeWare Community Code of Conduct`_.
@@ -184,11 +184,11 @@ Contributing
 If you experience problems with this backend, `log them on GitHub`_. If you
 want to contribute code, please `fork the code`_ and `submit a pull request`_.
 
-.. _BeeWare suite: http://pybee.org
+.. _BeeWare suite: http://beeware.org
 .. _Read The Docs: http://rubicon-java.readthedocs.org
-.. _@pybeeware on Twitter: https://twitter.com/pybeeware
-.. _pybee/general: https://gitter.im/pybee/general
-.. _BeeWare Community Code of Conduct: http://pybee.org/community/behavior/
-.. _log them on Github: https://github.com/pybee/rubicon-java/issues
-.. _fork the code: https://github.com/pybee/rubicon-java
-.. _submit a pull request: https://github.com/pybee/rubicon-java/pulls
+.. _@beewareware on Twitter: https://twitter.com/beewareware
+.. _beeware/general: https://gitter.im/beeware/general
+.. _BeeWare Community Code of Conduct: http://beeware.org/community/behavior/
+.. _log them on Github: https://github.com/beeware/rubicon-java/issues
+.. _fork the code: https://github.com/beeware/rubicon-java
+.. _submit a pull request: https://github.com/beeware/rubicon-java/pulls

--- a/jni/rubicon.c
+++ b/jni/rubicon.c
@@ -808,7 +808,7 @@ jobjectRefType GetObjectRefType(jobject obj) {
 /**************************************************************************
  * Method to start the Python runtime.
  *************************************************************************/
-JNIEXPORT jint JNICALL Java_org_pybee_rubicon_Python_start(JNIEnv *env, jobject thisObj, jstring pythonHome, jstring pythonPath, jstring rubiconLib) {
+JNIEXPORT jint JNICALL Java_org_beeware_rubicon_Python_start(JNIEnv *env, jobject thisObj, jstring pythonHome, jstring pythonPath, jstring rubiconLib) {
     int ret = 0;
     char pythonPathVar[512];
     char rubiconLibVar[256];
@@ -927,7 +927,7 @@ JNIEXPORT jint JNICALL Java_org_pybee_rubicon_Python_start(JNIEnv *env, jobject 
 /**************************************************************************
  * Method to stop the Python runtime.
  *************************************************************************/
-JNIEXPORT jint JNICALL Java_org_pybee_rubicon_Python_run(JNIEnv *env, jobject thisObj, jstring appName) {
+JNIEXPORT jint JNICALL Java_org_beeware_rubicon_Python_run(JNIEnv *env, jobject thisObj, jstring appName) {
     int ret = 0;
 
     // Search for and start entry script
@@ -950,7 +950,7 @@ JNIEXPORT jint JNICALL Java_org_pybee_rubicon_Python_run(JNIEnv *env, jobject th
 /**************************************************************************
  * Method to stop the Python runtime.
  *************************************************************************/
-JNIEXPORT void JNICALL Java_org_pybee_rubicon_Python_stop(JNIEnv *env, jobject thisObj) {
+JNIEXPORT void JNICALL Java_org_beeware_rubicon_Python_stop(JNIEnv *env, jobject thisObj) {
     if (java) {
         LOG_D("Finalizing Python runtime...");
         Py_Finalize();
@@ -969,10 +969,10 @@ JNIEXPORT void JNICALL Java_org_pybee_rubicon_Python_stop(JNIEnv *env, jobject t
  * This method converts the Python method invocation into a call on the
  * method dispatch method that has been registered as part of the runtime.
  *************************************************************************/
-JNIEXPORT jobject JNICALL Java_org_pybee_rubicon_PythonInstance_invoke(JNIEnv *env, jobject thisObj, jobject proxy, jobject method, jobjectArray jargs) {
+JNIEXPORT jobject JNICALL Java_org_beeware_rubicon_PythonInstance_invoke(JNIEnv *env, jobject thisObj, jobject proxy, jobject method, jobjectArray jargs) {
     LOG_D("Invocation");
 
-    jclass PythonInstance = (*env)->FindClass(env, "org/pybee/rubicon/PythonInstance");
+    jclass PythonInstance = (*env)->FindClass(env, "org/beeware/rubicon/PythonInstance");
     LOG_D("PythonInstance: %ld", (long)PythonInstance);
     jfieldID PythonInstance__id = (*env)->GetFieldID(env, PythonInstance, "instance", "J");
     LOG_D("id: %ld", (long)PythonInstance__id);

--- a/jni/rubicon.h
+++ b/jni/rubicon.h
@@ -1,40 +1,40 @@
 #include <jni.h>
 
-#ifndef _Included_org_pybee_rubicon
-#define _Included_org_pybee_rubicon
+#ifndef _Included_org_beeware_rubicon
+#define _Included_org_beeware_rubicon
 #ifdef __cplusplus
 extern "C" {
 #endif
 /*
- * Class:     org_pybee_Python
+ * Class:     org_beeware_Python
  * Method:    start
  * Signature: (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)I
  */
-JNIEXPORT jint JNICALL Java_org_pybee_rubicon_Python_start
+JNIEXPORT jint JNICALL Java_org_beeware_rubicon_Python_start
   (JNIEnv *, jobject, jstring, jstring, jstring);
 
 /*
- * Class:     org_pybee_Python
+ * Class:     org_beeware_Python
  * Method:    run
  * Signature: (Ljava/lang/String;)I
  */
-JNIEXPORT jint JNICALL Java_org_pybee_rubicon_Python_run
+JNIEXPORT jint JNICALL Java_org_beeware_rubicon_Python_run
   (JNIEnv *, jobject, jstring);
 
 /*
- * Class:     org_pybee_Python
+ * Class:     org_beeware_Python
  * Method:    stop
  * Signature: ()V
  */
-JNIEXPORT void JNICALL Java_org_pybee_rubicon_Python_stop
+JNIEXPORT void JNICALL Java_org_beeware_rubicon_Python_stop
   (JNIEnv *, jobject);
 
 /*
- * Class:     org_pybee_PythonInstance
+ * Class:     org_beeware_PythonInstance
  * Method:    invoke
  * Signature: (Ljava/lang/Object;Ljava/lang/reflect/Method;[Ljava/lang/Object;)Ljava/lang/Object;
  */
-JNIEXPORT jobject JNICALL Java_org_pybee_rubicon_PythonInstance_invoke
+JNIEXPORT jobject JNICALL Java_org_beeware_rubicon_PythonInstance_invoke
   (JNIEnv *, jobject, jobject, jobject, jobjectArray);
 
 #ifdef __cplusplus

--- a/org/beeware/rubicon/Python.java
+++ b/org/beeware/rubicon/Python.java
@@ -1,4 +1,4 @@
-package org.pybee.rubicon;
+package org.beeware.rubicon;
 
 import java.lang.reflect.Proxy;
 

--- a/org/beeware/rubicon/PythonInstance.java
+++ b/org/beeware/rubicon/PythonInstance.java
@@ -1,4 +1,4 @@
-package org.pybee.rubicon;
+package org.beeware.rubicon;
 
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;

--- a/org/beeware/rubicon/test/AbstractCallback.java
+++ b/org/beeware/rubicon/test/AbstractCallback.java
@@ -1,4 +1,4 @@
-package org.pybee.rubicon.test;
+package org.beeware.rubicon.test;
 
 
 public abstract class AbstractCallback implements ICallback {

--- a/org/beeware/rubicon/test/BaseExample.java
+++ b/org/beeware/rubicon/test/BaseExample.java
@@ -1,4 +1,4 @@
-package org.pybee.rubicon.test;
+package org.beeware.rubicon.test;
 
 
 public class BaseExample {

--- a/org/beeware/rubicon/test/Example.java
+++ b/org/beeware/rubicon/test/Example.java
@@ -1,8 +1,8 @@
-package org.pybee.rubicon.test;
+package org.beeware.rubicon.test;
 
 import java.lang.Math;
 
-import org.pybee.rubicon.Python;
+import org.beeware.rubicon.Python;
 
 
 public class Example extends BaseExample {

--- a/org/beeware/rubicon/test/ICallback.java
+++ b/org/beeware/rubicon/test/ICallback.java
@@ -1,4 +1,4 @@
-package org.pybee.rubicon.test;
+package org.beeware.rubicon.test;
 
 
 public interface ICallback {

--- a/org/beeware/rubicon/test/Test.java
+++ b/org/beeware/rubicon/test/Test.java
@@ -1,6 +1,6 @@
-package org.pybee.rubicon.test;
+package org.beeware.rubicon.test;
 
-import org.pybee.rubicon.Python;
+import org.beeware.rubicon.Python;
 
 
 public class Test {

--- a/org/beeware/rubicon/test/Thing.java
+++ b/org/beeware/rubicon/test/Thing.java
@@ -1,6 +1,6 @@
-package org.pybee.rubicon.test;
+package org.beeware.rubicon.test;
 
-import org.pybee.rubicon.Python;
+import org.beeware.rubicon.Python;
 
 
 public class Thing {

--- a/rubicon/java/jni.py
+++ b/rubicon/java/jni.py
@@ -422,7 +422,7 @@ class _ReflectionAPI(object):
             'Modifier__isStatic': ('GetStaticMethodID', 'Modifier', 'isStatic', '(I)Z'),
             'Modifier__isPublic': ('GetStaticMethodID', 'Modifier', 'isPublic', '(I)Z'),
 
-            'Python': ('FindClass', 'org/pybee/rubicon/Python'),
+            'Python': ('FindClass', 'org/beeware/rubicon/Python'),
             'Python__proxy': ('GetStaticMethodID', 'Python', 'proxy', '(Ljava/lang/Class;J)Ljava/lang/Object;'),
             'Python__getField': ('GetStaticMethodID', 'Python', 'getField', '(Ljava/lang/Class;Ljava/lang/String;Z)Ljava/lang/reflect/Field;'),
             'Python__getMethods': ('GetStaticMethodID', 'Python', 'getMethods', '(Ljava/lang/Class;Ljava/lang/String;Z)[Ljava/lang/reflect/Method;'),

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     long_description=long_description,
     author='Russell Keith-Magee',
     author_email='russell@keith-magee.com',
-    url='http://pybee.org/rubicon',
+    url='http://beeware.org/rubicon',
     packages=find_packages(exclude=['tests']),
     namespace_packages=['rubicon'],
     license='New BSD',

--- a/tests/test_jni.py
+++ b/tests/test_jni.py
@@ -22,7 +22,7 @@ class JNITest(TestCase):
         self.assertIsNone(UnknownClass.value)
 
         # A class that does exist, that we can then search for non-existent methods
-        Example = java.FindClass("org/pybee/rubicon/test/Example")
+        Example = java.FindClass("org/beeware/rubicon/test/Example")
         self.assertIsNotNone(Example.value)
 
         # Fields and Methods (static and non-static)
@@ -39,8 +39,8 @@ class JNITest(TestCase):
 
     def test_object_lifecycle(self):
         "The basic lifecycle operations of an object can be performed"
-        # Get a reference to the org.pybee.test.Example class
-        Example = java.FindClass("org/pybee/rubicon/test/Example")
+        # Get a reference to the org.beeware.test.Example class
+        Example = java.FindClass("org/beeware/rubicon/test/Example")
         self.assertIsNotNone(Example.value)
 
         # Find the default constructor
@@ -79,7 +79,7 @@ class JNITest(TestCase):
         Example__base_int_field = java.GetFieldID(Example, "base_int_field", "I")
         self.assertIsNotNone(Example__base_int_field.value)
 
-        # Create an instance of org.pybee.test.Example using the default constructor
+        # Create an instance of org.beeware.test.Example using the default constructor
         obj1 = java.NewObject(Example, Example__init)
         self.assertIsNotNone(obj1.value)
 
@@ -101,7 +101,7 @@ class JNITest(TestCase):
         self.assertEqual(java.GetIntField(obj1, Example__base_int_field), 1137)
         self.assertEqual(java.GetIntField(obj1, Example__int_field), 1142)
 
-        # Create an instance of org.pybee.test.Example using the "one int" constructor
+        # Create an instance of org.beeware.test.Example using the "one int" constructor
         obj2 = java.NewObject(Example, Example__init_i, 2242)
         self.assertIsNotNone(obj2)
 
@@ -112,7 +112,7 @@ class JNITest(TestCase):
         self.assertEqual(java.GetIntField(obj2, Example__base_int_field), 44)
         self.assertEqual(java.GetIntField(obj2, Example__int_field), 2242)
 
-        # Create an instance of org.pybee.test.Example using the "two int" constructor
+        # Create an instance of org.beeware.test.Example using the "two int" constructor
         obj3 = java.NewObject(Example, Example__init_ii, 3342, 3337)
         self.assertIsNotNone(obj3)
 
@@ -125,8 +125,8 @@ class JNITest(TestCase):
 
     def test_static(self):
         "Static methods and fields can be invoked"
-        # Get a reference to the org.pybee.test.Example class
-        Example = java.FindClass("org/pybee/rubicon/test/Example")
+        # Get a reference to the org.beeware.test.Example class
+        Example = java.FindClass("org/beeware/rubicon/test/Example")
         self.assertIsNotNone(Example.value)
 
         # Find the BaseExample.set_static_base_int_field() method on Example
@@ -177,7 +177,7 @@ class JNITest(TestCase):
         s = "Woop"
         java_string = java.NewStringUTF(s.encode('utf-8'))
 
-        Example = java.FindClass("org/pybee/rubicon/test/Example")
+        Example = java.FindClass("org/beeware/rubicon/test/Example")
         self.assertIsNotNone(Example.value)
 
         # Find the default constructor
@@ -188,7 +188,7 @@ class JNITest(TestCase):
         Example__duplicate_string = java.GetMethodID(Example, "duplicate_string", "(Ljava/lang/String;)Ljava/lang/String;")
         self.assertIsNotNone(Example__duplicate_string.value)
 
-        # Create an instance of org.pybee.test.Example using the default constructor
+        # Create an instance of org.beeware.test.Example using the default constructor
         obj1 = java.NewObject(Example, Example__init)
         self.assertIsNotNone(obj1.value)
 
@@ -199,7 +199,7 @@ class JNITest(TestCase):
     def test_float_method(self):
         "A Java float can be created, and the content returned"
         # This string contains unicode characters
-        Example = java.FindClass("org/pybee/rubicon/test/Example")
+        Example = java.FindClass("org/beeware/rubicon/test/Example")
         self.assertIsNotNone(Example.value)
 
         # Find the default constructor
@@ -210,7 +210,7 @@ class JNITest(TestCase):
         Example__area_of_square = java.GetMethodID(Example, "area_of_square", "(F)F")
         self.assertIsNotNone(Example__area_of_square.value)
 
-        # Create an instance of org.pybee.test.Example using the default constructor
+        # Create an instance of org.beeware.test.Example using the default constructor
         obj1 = java.NewObject(Example, Example__init)
         self.assertIsNotNone(obj1.value)
 

--- a/tests/test_rubicon.py
+++ b/tests/test_rubicon.py
@@ -28,7 +28,7 @@ class JNITest(TestCase):
 
     def test_field(self):
         "A field on an instance can be accessed and mutated"
-        Example = JavaClass('org/pybee/rubicon/test/Example')
+        Example = JavaClass('org/beeware/rubicon/test/Example')
 
         obj = Example()
 
@@ -43,7 +43,7 @@ class JNITest(TestCase):
 
     def test_method(self):
         "An instance method can be invoked."
-        Example = JavaClass('org/pybee/rubicon/test/Example')
+        Example = JavaClass('org/beeware/rubicon/test/Example')
 
         obj = Example()
         self.assertEqual(obj.get_base_int_field(), 22)
@@ -57,7 +57,7 @@ class JNITest(TestCase):
 
     def test_static_field(self):
         "A static field on a class can be accessed and mutated"
-        Example = JavaClass('org/pybee/rubicon/test/Example')
+        Example = JavaClass('org/beeware/rubicon/test/Example')
 
         Example.set_static_base_int_field(1)
         Example.set_static_int_field(11)
@@ -73,7 +73,7 @@ class JNITest(TestCase):
 
     def test_static_method(self):
         "A static method on a class can be invoked."
-        Example = JavaClass('org/pybee/rubicon/test/Example')
+        Example = JavaClass('org/beeware/rubicon/test/Example')
 
         Example.set_static_base_int_field(2288)
         Example.set_static_int_field(2299)
@@ -83,7 +83,7 @@ class JNITest(TestCase):
 
     def test_non_existent_field(self):
         "An attribute error is raised if you invoke a non-existent field."
-        Example = JavaClass('org/pybee/rubicon/test/Example')
+        Example = JavaClass('org/beeware/rubicon/test/Example')
 
         obj1 = Example()
 
@@ -97,7 +97,7 @@ class JNITest(TestCase):
 
     def test_non_existent_method(self):
         "An attribute error is raised if you invoke a non-existent method."
-        Example = JavaClass('org/pybee/rubicon/test/Example')
+        Example = JavaClass('org/beeware/rubicon/test/Example')
 
         obj1 = Example()
 
@@ -111,7 +111,7 @@ class JNITest(TestCase):
 
     def test_non_existent_static_field(self):
         "An attribute error is raised if you invoke a non-existent static field."
-        Example = JavaClass('org/pybee/rubicon/test/Example')
+        Example = JavaClass('org/beeware/rubicon/test/Example')
 
         # Non-existent fields raise an error.
         with self.assertRaises(AttributeError):
@@ -123,7 +123,7 @@ class JNITest(TestCase):
 
     def test_non_existent_static_method(self):
         "An attribute error is raised if you invoke a non-existent static method."
-        Example = JavaClass('org/pybee/rubicon/test/Example')
+        Example = JavaClass('org/beeware/rubicon/test/Example')
 
         # Non-existent methods raise an error.
         with self.assertRaises(AttributeError):
@@ -135,7 +135,7 @@ class JNITest(TestCase):
 
     def test_protected_field(self):
         "An attribute error is raised if you invoke a non-public field."
-        Example = JavaClass('org/pybee/rubicon/test/Example')
+        Example = JavaClass('org/beeware/rubicon/test/Example')
 
         obj1 = Example()
 
@@ -149,7 +149,7 @@ class JNITest(TestCase):
 
     def test_protected_method(self):
         "An attribute error is raised if you invoke a non-public method."
-        Example = JavaClass('org/pybee/rubicon/test/Example')
+        Example = JavaClass('org/beeware/rubicon/test/Example')
 
         obj1 = Example()
 
@@ -163,7 +163,7 @@ class JNITest(TestCase):
 
     def test_protected_static_field(self):
         "An attribute error is raised if you invoke a non-public static field."
-        Example = JavaClass('org/pybee/rubicon/test/Example')
+        Example = JavaClass('org/beeware/rubicon/test/Example')
 
         # Non-public fields raise an error.
         with self.assertRaises(AttributeError):
@@ -175,7 +175,7 @@ class JNITest(TestCase):
 
     def test_protected_static_method(self):
         "An attribute error is raised if you invoke a non-public static method."
-        Example = JavaClass('org/pybee/rubicon/test/Example')
+        Example = JavaClass('org/beeware/rubicon/test/Example')
 
         # Non-public methods raise an error.
         with self.assertRaises(AttributeError):
@@ -187,7 +187,7 @@ class JNITest(TestCase):
 
     def test_polymorphic_constructor(self):
         "Check that the right constructor is activated based on arguments used"
-        Example = JavaClass('org/pybee/rubicon/test/Example')
+        Example = JavaClass('org/beeware/rubicon/test/Example')
 
         obj1 = Example()
         obj2 = Example(2242)
@@ -208,7 +208,7 @@ class JNITest(TestCase):
 
     def test_polymorphic_method(self):
         "Check that the right method is activated based on arguments used"
-        Example = JavaClass('org/pybee/rubicon/test/Example')
+        Example = JavaClass('org/beeware/rubicon/test/Example')
 
         obj1 = Example()
 
@@ -221,7 +221,7 @@ class JNITest(TestCase):
 
     def test_polymorphic_static_method(self):
         "Check that the right static method is activated based on arguments used"
-        Example = JavaClass('org/pybee/rubicon/test/Example')
+        Example = JavaClass('org/beeware/rubicon/test/Example')
 
         self.assertEqual(Example.tripler(42), 126)
         self.assertEqual(Example.tripler("wibble"), "wibblewibblewibble")
@@ -232,7 +232,7 @@ class JNITest(TestCase):
 
     def test_static_access_non_static(self):
         "An instance field/method cannot be accessed from the static context"
-        Example = JavaClass('org/pybee/rubicon/test/Example')
+        Example = JavaClass('org/beeware/rubicon/test/Example')
 
         obj = Example()
 
@@ -244,7 +244,7 @@ class JNITest(TestCase):
 
     def test_non_static_access_static(self):
         "A static field/method cannot be accessed from an instance context"
-        Example = JavaClass('org/pybee/rubicon/test/Example')
+        Example = JavaClass('org/beeware/rubicon/test/Example')
 
         with self.assertRaises(AttributeError):
             Example.int_field
@@ -254,34 +254,34 @@ class JNITest(TestCase):
 
     def test_string_argument(self):
         "A method with a string argument can be passed."
-        Example = JavaClass('org/pybee/rubicon/test/Example')
+        Example = JavaClass('org/beeware/rubicon/test/Example')
         example = Example()
         self.assertEqual(example.duplicate_string("Wagga"), "WaggaWagga")
 
     def test_string_return(self):
         "If a method or field returns a string, you get a Python string back"
-        Example = JavaClass('org/pybee/rubicon/test/Example')
+        Example = JavaClass('org/beeware/rubicon/test/Example')
         example = Example()
         self.assertEqual(example.toString(), "This is a Java Example object")
 
     def test_float_method(self):
         "A method with a float arguments can be handled."
-        Example = JavaClass('org/pybee/rubicon/test/Example')
+        Example = JavaClass('org/beeware/rubicon/test/Example')
         example = Example()
         self.assertEqual(example.area_of_square(1.5), 2.25)
 
     def test_double_method(self):
         "A method with a double arguments can be handled."
-        Example = JavaClass('org/pybee/rubicon/test/Example')
+        Example = JavaClass('org/beeware/rubicon/test/Example')
         example = Example()
         self.assertEqual(example.area_of_circle(1.5), 1.5 * math.pi)
 
     def test_enum_method(self):
         "A method with enum arguments can be handled."
-        Example = JavaClass('org/pybee/rubicon/test/Example')
+        Example = JavaClass('org/beeware/rubicon/test/Example')
         example = Example()
 
-        Stuff = JavaClass('org/pybee/rubicon/test/Example$Stuff')
+        Stuff = JavaClass('org/beeware/rubicon/test/Example$Stuff')
 
         self.assertEqual(example.label(Stuff.FOO), "Foo")
         self.assertEqual(example.label(Stuff.BAR), "Bar")
@@ -289,10 +289,10 @@ class JNITest(TestCase):
 
     def test_object_return(self):
         "If a method or field returns an object, you get an instance of that type returned"
-        Example = JavaClass('org/pybee/rubicon/test/Example')
+        Example = JavaClass('org/beeware/rubicon/test/Example')
         example = Example()
 
-        Thing = JavaClass('org/pybee/rubicon/test/Thing')
+        Thing = JavaClass('org/beeware/rubicon/test/Thing')
         thing = Thing('This is thing', 2)
 
         example.set_thing(thing)
@@ -302,7 +302,7 @@ class JNITest(TestCase):
 
     def test_interface(self):
         "An Java interface can be defined in Python and proxied."
-        ICallback = JavaInterface('org/pybee/rubicon/test/ICallback')
+        ICallback = JavaInterface('org/beeware/rubicon/test/ICallback')
 
         results = {}
 
@@ -325,7 +325,7 @@ class JNITest(TestCase):
         handler2 = MyInterface(10)
 
         # Create an Example object, and register a handler with it.
-        Example = JavaClass('org/pybee/rubicon/test/Example')
+        Example = JavaClass('org/beeware/rubicon/test/Example')
         example = Example()
         example.set_callback(handler2)
 
@@ -342,22 +342,22 @@ class JNITest(TestCase):
 
     def test_alternatives(self):
         "A class is aware of it's type heirarchy"
-        Example = JavaClass('org/pybee/rubicon/test/Example')
+        Example = JavaClass('org/beeware/rubicon/test/Example')
 
         self.assertEqual(
             Example.__dict__['_alternates'],
             [
-                "Lorg/pybee/rubicon/test/Example;",
-                "Lorg/pybee/rubicon/test/BaseExample;",
+                "Lorg/beeware/rubicon/test/Example;",
+                "Lorg/beeware/rubicon/test/BaseExample;",
                 "Ljava/lang/Object;",
             ])
 
-        AbstractCallback = JavaClass('org/pybee/rubicon/test/AbstractCallback')
+        AbstractCallback = JavaClass('org/beeware/rubicon/test/AbstractCallback')
         self.assertEqual(
             AbstractCallback.__dict__['_alternates'],
             [
-                "Lorg/pybee/rubicon/test/AbstractCallback;",
-                "Lorg/pybee/rubicon/test/ICallback;",
+                "Lorg/beeware/rubicon/test/AbstractCallback;",
+                "Lorg/beeware/rubicon/test/ICallback;",
                 "Ljava/lang/Object;",
             ])
 
@@ -376,6 +376,6 @@ class JNITest(TestCase):
     def test_inner(self):
         "Inner classes can be accessed"
 
-        Inner = JavaClass('org/pybee/rubicon/test/Example$Inner')
+        Inner = JavaClass('org/beeware/rubicon/test/Example$Inner')
 
         self.assertEqual(Inner.INNER_CONSTANT, 1234)


### PR DESCRIPTION
This is small pull request to rename PyBee to BeeWare.

I'm working on splitting out #5 into a few pull requests, mostly to improve my familiarity with this codebase.

I also removed two instances of trailing whitespace.

**Testing**

- Ran Java-based test suite.

```
➜  rubicon-java git:(pybee-beeware) java org.beeware.rubicon.test.Test
Start Python runtime...
Initializing Python runtime...
Import rubicon...
test_float_method (tests.test_jni.JNITest) ... ok
test_non_existent (tests.test_jni.JNITest) ... ok
test_object_lifecycle (tests.test_jni.JNITest) ... ok
test_static (tests.test_jni.JNITest) ... ok
test_string (tests.test_jni.JNITest) ... ok
test_string_method (tests.test_jni.JNITest) ... ok
test_alternatives (tests.test_rubicon.JNITest) ... ok
test_double_method (tests.test_rubicon.JNITest) ... ok
test_enum_method (tests.test_rubicon.JNITest) ... ok
test_field (tests.test_rubicon.JNITest) ... ok
test_float_method (tests.test_rubicon.JNITest) ... ok
test_inner (tests.test_rubicon.JNITest) ... ok
test_interface (tests.test_rubicon.JNITest) ... ok
test_method (tests.test_rubicon.JNITest) ... ok
test_non_existent_field (tests.test_rubicon.JNITest) ... ok
test_non_existent_method (tests.test_rubicon.JNITest) ... ok
test_non_existent_static_field (tests.test_rubicon.JNITest) ... ok
test_non_existent_static_method (tests.test_rubicon.JNITest) ... ok
test_non_static_access_static (tests.test_rubicon.JNITest) ... ok
test_object_return (tests.test_rubicon.JNITest) ... ok
test_polymorphic_constructor (tests.test_rubicon.JNITest) ... ok
test_polymorphic_method (tests.test_rubicon.JNITest) ... ok
test_polymorphic_static_method (tests.test_rubicon.JNITest) ... ok
test_protected_field (tests.test_rubicon.JNITest) ... ok
test_protected_method (tests.test_rubicon.JNITest) ... ok
test_protected_static_field (tests.test_rubicon.JNITest) ... ok
test_protected_static_method (tests.test_rubicon.JNITest) ... ok
test_simple_object (tests.test_rubicon.JNITest) ... ok
test_static_access_non_static (tests.test_rubicon.JNITest) ... ok
test_static_field (tests.test_rubicon.JNITest) ... ok
test_static_method (tests.test_rubicon.JNITest) ... ok
test_string_argument (tests.test_rubicon.JNITest) ... ok
test_string_return (tests.test_rubicon.JNITest) ... ok

----------------------------------------------------------------------
Ran 33 tests in 0.036s

OK
```

- Ran manual test to ensure Python starts (or at least, we get a 0 return code when trying to start Python)

```
➜  rubicon-java git:(pybee-beeware) jshell --class-path /home/paulproteus/projects/beeware/rubicon-java/dist/rubicon.jar
|  Welcome to JShell -- Version 11.0.4
|  For an introduction type: /help intro

jshell> import org.beeware.rubicon.Python;

jshell> org.beeware.rubicon.Python.start(null, "/home/paulproteus/projects/beeware/rubicon-java/", "/home/paulproteus/projects/beeware/rubicon-java/dist/librubicon.so")
$2 ==> 0

jshell>
```