### PR TITLE
Rely on python-config & JAVA_HOME through our compile process

### DIFF
--- a/.github/workflows/build_status.yml
+++ b/.github/workflows/build_status.yml
@@ -7,11 +7,12 @@ on:
 jobs:
   build:
     name: Unit tests
-    runs-on: ubuntu-18.04
     strategy:
       max-parallel: 4
       matrix:
         python-version: [2.7]
+        os: [ubuntu-18.04, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Environment - checkout code
         uses: actions/checkout@master
@@ -27,5 +28,9 @@ jobs:
         run: export
       - name: Compile
         run: make
-      - name: Test
+      - name: Test - Linux
+        if: matrix.os == 'ubuntu-18.04'
         run: RUBICON_LIBRARY=$(pwd)/dist/librubicon.so LD_LIBRARY_PATH="$(pwd)/dist" java org.beeware.rubicon.test.Test
+      - name: Test - Mac
+        if: matrix.os == 'macos-latest'
+        run: RUBICON_LIBRARY=$(pwd)/dist/librubicon.dylib DYLD_LIBRARY_PATH="$(pwd)/dist" java org.beeware.rubicon.test.Test

--- a/.github/workflows/build_status.yml
+++ b/.github/workflows/build_status.yml
@@ -1,3 +1,7 @@
+# Run just one build (one operating system, one Python version)
+# at merge time, so that we have an up-to-date GitHub Actions
+# build status badge in README.md. This is just a check that
+# nothing obviously bad has gone wrong when merging a pull request.
 name: Build status
 on:
   push:
@@ -7,19 +11,14 @@ on:
 jobs:
   build:
     name: Unit tests
-    strategy:
-      max-parallel: 4
-      matrix:
-        python-version: [2.7]
-        os: [ubuntu-18.04, macos-latest]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-18.04
     steps:
       - name: Environment - checkout code
         uses: actions/checkout@master
       - name: Environment - Setup python
         uses: actions/setup-python@v1
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: 2.7
       - name: Environment - Use Java 8
         uses: actions/setup-java@v1
         with:
@@ -29,8 +28,4 @@ jobs:
       - name: Compile
         run: make
       - name: Test - Linux
-        if: matrix.os == 'ubuntu-18.04'
         run: RUBICON_LIBRARY=$(pwd)/dist/librubicon.so LD_LIBRARY_PATH="$(pwd)/dist" java org.beeware.rubicon.test.Test
-      - name: Test - Mac
-        if: matrix.os == 'macos-latest'
-        run: RUBICON_LIBRARY=$(pwd)/dist/librubicon.dylib DYLD_LIBRARY_PATH="$(pwd)/dist" java org.beeware.rubicon.test.Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,11 +5,12 @@ on:
 jobs:
   build:
     name: Unit tests
-    runs-on: ubuntu-18.04
     strategy:
       max-parallel: 4
       matrix:
         python-version: [2.7]
+        os: [ubuntu-18.04, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Environment - checkout code
         uses: actions/checkout@master
@@ -25,5 +26,9 @@ jobs:
         run: export
       - name: Compile
         run: make
-      - name: Test
+      - name: Test - Linux
+        if: matrix.os == 'ubuntu-18.04'
         run: RUBICON_LIBRARY=$(pwd)/dist/librubicon.so LD_LIBRARY_PATH="$(pwd)/dist" java org.beeware.rubicon.test.Test
+      - name: Test - Mac
+        if: matrix.os == 'macos-latest'
+        run: RUBICON_LIBRARY=$(pwd)/dist/librubicon.dylib DYLD_LIBRARY_PATH="$(pwd)/dist" java org.beeware.rubicon.test.Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,4 @@
+# Test rubicon-java on all supported operating systems & Python versions.
 name: CI
 on:
   pull_request
@@ -22,13 +23,9 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 8
-      - name: Debugging - Export environment variables
+      - name: Debug log - Print exported environment variables
         run: export
       - name: Compile
         run: make
-      - name: Test - Linux
-        if: matrix.os == 'ubuntu-18.04'
-        run: RUBICON_LIBRARY=$(pwd)/dist/librubicon.so LD_LIBRARY_PATH="$(pwd)/dist" java org.beeware.rubicon.test.Test
-      - name: Test - Mac
-        if: matrix.os == 'macos-latest'
-        run: RUBICON_LIBRARY=$(pwd)/dist/librubicon.dylib DYLD_LIBRARY_PATH="$(pwd)/dist" java org.beeware.rubicon.test.Test
+      - name: Test
+        run: RUBICON_LIBRARY="${PWD}/dist/librubicon.${{ runner.os == 'Linux' && 'so' || 'dylib' }}" ${{ runner.os == 'Linux' && 'LD_' || 'DYLD_' }}LIBRARY_PATH="$(pwd)/dist" java org.beeware.rubicon.test.Test


### PR DESCRIPTION
This is intended to help us smoothly use whatever `python` is on
`$PATH`, and whatever Java version is configured via `JAVA_HOME`.

In the process:

Pass `-fPIC` to GCC on both macOS and Linux. This seems to work fine.

Compute JAVA_PLATFORM (include path) based on `uname -s` output.

Rename PYLDFLAGS variable to LDFLAGS.