### PR TITLE
Use signed 64-bit int for jlong with printf & _proxy_cache

### DIFF
--- a/jni/rubicon.c
+++ b/jni/rubicon.c
@@ -1027,7 +1027,7 @@ JNIEXPORT jobject JNICALL Java_org_beeware_rubicon_PythonInstance_invoke(JNIEnv 
 
     jlong instance = (*env)->GetLongField(env, thisObj, PythonInstance__id);
     // Since `jlong` is a signed 64-bit integer, we use a relevant macro.
-    LOG_D("instance: " PRId64, instance);
+    LOG_D("instance: %" PRId64, instance);
 
     jclass Method = (*env)->FindClass(env, "java/lang/reflect/Method");
     jmethodID method__getName = (*env)->GetMethodID(env, Method, "getName", "()Ljava/lang/String;");

--- a/rubicon/java/api.py
+++ b/rubicon/java/api.py
@@ -9,7 +9,8 @@ from .types import *
 _class_cache = {}
 
 # A cache of known JavaInterface proxies. This is used by the dispatch
-# mechanism to direct callbacks to the right place.
+# mechanism to direct callbacks to the right place, keyed by jlong(id(obj)).value
+# to ensure no information loss when round-tripping to Java.
 _proxy_cache = {}
 
 
@@ -29,7 +30,7 @@ def dispatch(instance, method, args):
     """
     try:
         # print ("PYTHON SIDE DISPATCH", instance, method, args)
-        pyinstance = _proxy_cache[instance]
+        pyinstance = _proxy_cache[jlong(instance).value]
         signatures = pyinstance._methods.get(method)
 
         if len(signatures) == 1:
@@ -961,7 +962,7 @@ class JavaProxy(object):
         # not an actual user of proxy objects. If all references to the
         # proxy disappear, the proxy cache should be cleaned to avoid
         # leaking memory on objects that aren't being used.
-        _proxy_cache[id(self)] = self
+        _proxy_cache[jlong(id(self)).value] = self
 
         self._as_parameter_ = self.__jni__
 


### PR DESCRIPTION
This fixes one bug: We were storing incorrect values in `instance` within the Java class `PythonInstance`.`jlong` is 64-bits, but we were truncating `jlong` to 32-bits on 32-bit platforms. 

To help future debugging, we now use a 64-bit signed int value within _both_ Python's `_proxy_cache` and the Java `PythonInstance.instance`. Note that this doesn't truncate `id(self)`; it re-interprets numbers > 2**63 as negative numbers, which is fine with me.