### PR TITLE
Use python3-config by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # You can set PYTHON and PYTHON_CONFIG to a specific python-config binary if you want to build
 # against a specific version of Python.
 ifndef PYTHON_CONFIG
-	PYTHON_CONFIG := python-config
+	PYTHON_CONFIG := python3-config
 endif
 ifndef PYTHON
 	PYTHON := python

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ ifndef PYTHON_CONFIG
 	PYTHON_CONFIG := python3-config
 endif
 ifndef PYTHON
-	PYTHON := python
+	PYTHON := python3
 endif
 
 CFLAGS := $(shell $(PYTHON_CONFIG) --cflags) -fPIC


### PR DESCRIPTION
On my laptop, I have Python 2 installed as `python`, and therefore
its config tool is available as `python-config`. If rubicon-java
uses it to build, it yields an error because rubicon-java only
supports Python 3.

Using `python3-config` would do the right thing if you only have one
Python 3 version available, and it is already in $PATH appropriately,
so let's go with that.