### PR TITLE
Adjust `Python.run()` to take a module name and set `__main__`

### DIFF
--- a/org/beeware/rubicon/Python.java
+++ b/org/beeware/rubicon/Python.java
@@ -45,10 +45,10 @@ public class Python {
     public static native int init(String pythonHome, String pythonPath, String rubiconLib);
 
     /**
-     * Create a proxy implementation that directs towards a Python instance.
+     * Run a Python module as __main__.
      *
-     * @param script The path to the Python script to run
-     * @param args   The value for argv to pass to the script
+     * @param module The name of the Python module to run. Dots are OK, e.g., myapp.main.
+     * @param args   The value for Python's sys.argv.
      * @return 0 on success; non-zero on failure.
      */
     public static native int run(String script, String[] args);

--- a/org/beeware/rubicon/test/Test.java
+++ b/org/beeware/rubicon/test/Test.java
@@ -9,7 +9,7 @@ public class Test {
             System.exit(1);
         }
 
-        if (Python.run("tests/runner.py", args) != 0) {
+        if (Python.run("tests.runner", args) != 0) {
             System.err.println("Got an error running Python script");
             System.exit(1);
         }

--- a/tests/test_rubicon.py
+++ b/tests/test_rubicon.py
@@ -1,4 +1,5 @@
 import math
+import sys
 from unittest import TestCase
 
 from rubicon.java import JavaClass, JavaInterface
@@ -377,6 +378,11 @@ class JNITest(TestCase):
         Inner = JavaClass('org/beeware/rubicon/test/Example$Inner')
 
         self.assertEqual(Inner.INNER_CONSTANT, 1234)
+
+    def test_dunder_main(self):
+        "When launched from `rubicon-java`, sys.modules should have a `__main__` module."
+        self.assertEqual('module', sys.modules['__main__'].__class__.__name__)
+
 
 class ExampleClassWithCleanup(object):
     '''Returns the `Example` JavaClass, wrapped in a context manager


### PR DESCRIPTION
This is based heavily on https://github.com/beeware/briefcase-iOS-Xcode-template/blob/dev/%7B%7B%20cookiecutter.formal_name%20%7D%7D/%7B%7B%20cookiecutter.app_name%20%7D%7D/main.m .

This PR doesn't free some `PyObject *` references it introduces. The XCode template doesn't either. I'm willing to free them, but I haven't thought hard yet about these objects' lifecycle, so any advice is welcome. I'm also fine just ignoring the possibility of a memory leak if the user runs `.run()` 10,000 times.