### PR TITLE
Explain new environment variables in README.rst

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,8 +67,17 @@ dist/librubicon.$(SOEXT): jni/rubicon.o
 	mkdir -p dist
 	$(CC) -shared -o $@ $< $(LDFLAGS)
 
+PYTHON_LIBS_DIR := $(shell echo `dirname $(PYTHON_CONFIG)`/../Lib)
+
 test: all
-	java org.beeware.rubicon.test.Test
+# Rather than test which OS we're on, we set the Mac DYLD_LIBRARY_PATH as
+# well as the the LD_LIBRARY_PATH variable seen on Linux. Additionally, the Mac
+# variable seems to get stripped when running some tools, so it's helpful to
+# add it here rather than ask the user to set it in their environment.
+	DYLD_LIBRARY_PATH=$(PYTHON_LIBS_DIR) \
+		LD_LIBRARY_PATH=$(PYTHON_LIBS_DIR) \
+		RUBICON_LIBRARY=$(shell ls ./dist/librubicon.*) \
+		java -Djava.library.path="./dist" org.beeware.rubicon.test.Test
 
 clean:
 	rm -f org/beeware/rubicon/test/*.class

--- a/README.rst
+++ b/README.rst
@@ -149,21 +149,24 @@ Testing
 
 To run the Rubicon test suite:
 
-1. Configure your shell environment so that the Python, Java, and Rubicon
-   dynamic libraries can be discovered by the dynamic linker.
+1. Configure your shell environment to point to a ``PYTHON_CONFIG`` binary.
+   `virtualenv` and `venv` do not necessarily put the ``python3-config`` binary
+   on your ``$PATH``, but you can use this expression to set it properly::
 
-   * On OSX, using Python 2.7.7 built under Homebrew::
+    $ export PYTHON_CONFIG="$(python3 -c 'import sys; from pathlib import Path; print(str(Path(sys.executable).resolve()) + "-config")')"
 
-        export DYLD_LIBRARY_PATH=/usr/local/Cellar/python/2.7.7_2/Frameworks/Python.framework/Versions/2.7/lib/:`/usr/libexec/java_home`/jre/lib/server:./dist
+2. Ensure that ``java`` is on your ``$PATH``, or set the ``JAVA_HOME`` environment
+   variable to point to a directory of a Java Development Kit (JDK).
 
-2. Build the libraries::
+3. Build the libraries::
 
     $ make clean
     $ make all
 
-3. Run the test suite::
+4. Run the test suite, specifying the path to the compiled library. The following
+   should work properly on both macOS and Linux::
 
-    $ java org.beeware.rubicon.test.Test
+    $ make test
 
 This is a Python test suite, invoked via Java.
 


### PR DESCRIPTION
In addition, move some linker complexity into the `Makefile`
because otherwise it's too hard to explain.

This may allow us to simplify the GitHub Actions configuration,
too.