### PR TITLE
Use tox to drive CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
         env:
           PKG_CONFIG_PATH: ${{ env.pythonLocation }}/lib/pkgconfig/
         run: |
-          PYTHON_CONFIG=$(which python${{ matrix.python-version }}-config) tox -e py
+          PYTHON_CONFIG=$(which python${{ matrix.python-version }}-config) LIBRARY_PATH="${{ env.pythonLocation }}/lib" tox -e py
 
 
   # Now test on all recent versions of Python as well.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
         env:
           PKG_CONFIG_PATH: ${{ env.pythonLocation }}/lib/pkgconfig/
         run: |
-          PYTHON_CONFIG="python${{ matrix.python-version }}-config" LIBRARY_PATH="${{ env.pythonLocation }}/lib" tox -e py
+          PYTHON_CONFIG=`which python${{ matrix.python-version }}-config` tox -e py
 
 
   # Now test on all recent versions of Python as well.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
         env:
           PKG_CONFIG_PATH: ${{ env.pythonLocation }}/lib/pkgconfig/
         run: |
-          PYTHON_CONFIG=`which python${{ matrix.python-version }}-config` tox -e py
+          PYTHON_CONFIG=$(which python${{ matrix.python-version }}-config) tox -e py
 
 
   # Now test on all recent versions of Python as well.
@@ -117,7 +117,7 @@ jobs:
         env:
           PKG_CONFIG_PATH: ${{ env.pythonLocation }}/lib/pkgconfig/
         run: |
-          PYTHON_CONFIG=`which python${{ matrix.python-version }}-config` tox -e py
+          PYTHON_CONFIG=$(which python${{ matrix.python-version }}-config) LIBRARY_PATH="${{ env.pythonLocation }}/lib" tox -e py
 
   # Test on x86 (32-bit) Ubuntu 18.04, focusing on 32-bit/64-bit errors; just one Python version.
   x86:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,7 +117,7 @@ jobs:
         env:
           PKG_CONFIG_PATH: ${{ env.pythonLocation }}/lib/pkgconfig/
         run: |
-          PYTHON_CONFIG="python${{ matrix.python-version }}-config" LIBRARY_PATH="${{ env.pythonLocation }}/lib" tox -e py
+          PYTHON_CONFIG=`which python${{ matrix.python-version }}-config` tox -e py
 
   # Test on x86 (32-bit) Ubuntu 18.04, focusing on 32-bit/64-bit errors; just one Python version.
   x86:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,10 +63,13 @@ jobs:
           python -m pip install --upgrade setuptools
           python -m pip install tox
       - name: Test
+          # For the Python 3.5 and 3.7 distributions on macOS in GitHub Actions,
+          # python-config --ldflags refuses to print a -L directive. We work around
+          # that with the LIBRARY_PATH variable below.
         env:
           PKG_CONFIG_PATH: ${{ env.pythonLocation }}/lib/pkgconfig/
         run: |
-          PYTHON_CONFIG=$(which python${{ matrix.python-version }}-config) tox -e py
+          PYTHON_CONFIG=$(which python${{ matrix.python-version }}-config) LIBRARY_PATH="${{ env.pythonLocation }}/lib" tox -e py
 
 
   # Now test on all recent versions of Python as well.
@@ -96,10 +99,13 @@ jobs:
           python -m pip install --upgrade setuptools
           python -m pip install tox
       - name: Test
+          # For the Python 3.5 and 3.7 distributions on macOS in GitHub Actions,
+          # python-config --ldflags refuses to print a -L directive. We work around
+          # that with the LIBRARY_PATH variable below.
         env:
           PKG_CONFIG_PATH: ${{ env.pythonLocation }}/lib/pkgconfig/
         run: |
-          PYTHON_CONFIG=$(which python${{ matrix.python-version }}-config) tox -e py
+          PYTHON_CONFIG=$(which python${{ matrix.python-version }}-config) LIBRARY_PATH="${{ env.pythonLocation }}/lib" tox -e py
 
   # Test on x86 (32-bit) Ubuntu 18.04, focusing on 32-bit/64-bit errors; just one Python version.
   x86:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,8 +69,13 @@ jobs:
           python -m pip install --upgrade setuptools
           python -m pip install tox
       - name: Test
+          # For the Python 3.5 and 3.7 distributions on macOS in GitHub Actions,
+          # python-config --ldflags refuses to print a -L directive. We work around
+          # that with the LIBRARY_PATH variable below.
+        env:
+          PKG_CONFIG_PATH: ${{ env.pythonLocation }}/lib/pkgconfig/
         run: |
-          tox -e py
+          PYTHON_CONFIG="python${{ matrix.python-version }}-config" LIBRARY_PATH="${{ env.pythonLocation }}/lib" tox -e py
 
 
   # Now test on all recent versions of Python as well.
@@ -106,8 +111,13 @@ jobs:
           python -m pip install --upgrade setuptools
           python -m pip install tox
       - name: Test
+          # For the Python 3.5 and 3.7 distributions on macOS in GitHub Actions,
+          # python-config --ldflags refuses to print a -L directive. We work around
+          # that with the LIBRARY_PATH variable below.
+        env:
+          PKG_CONFIG_PATH: ${{ env.pythonLocation }}/lib/pkgconfig/
         run: |
-          tox -e py
+          PYTHON_CONFIG="python${{ matrix.python-version }}-config" LIBRARY_PATH="${{ env.pythonLocation }}/lib" tox -e py
 
   # Test on x86 (32-bit) Ubuntu 18.04, focusing on 32-bit/64-bit errors; just one Python version.
   x86:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,25 +57,16 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 8
-      - name: Debug log - Print environment variables and python-config output
-        run: |
-          set -x  # To print command names along with their output
-          export
-          python${{ matrix.python-version }}-config --ldflags
-          python${{ matrix.python-version }}-config --cflags
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           python -m pip install --upgrade setuptools
           python -m pip install tox
       - name: Test
-          # For the Python 3.5 and 3.7 distributions on macOS in GitHub Actions,
-          # python-config --ldflags refuses to print a -L directive. We work around
-          # that with the LIBRARY_PATH variable below.
         env:
           PKG_CONFIG_PATH: ${{ env.pythonLocation }}/lib/pkgconfig/
         run: |
-          PYTHON_CONFIG=$(which python${{ matrix.python-version }}-config) LIBRARY_PATH="${{ env.pythonLocation }}/lib" tox -e py
+          PYTHON_CONFIG=$(which python${{ matrix.python-version }}-config) tox -e py
 
 
   # Now test on all recent versions of Python as well.
@@ -99,25 +90,16 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 8
-      - name: Debug log - Print environment variables and python-config output
-        run: |
-          set -x  # To print command names along with their output
-          export
-          python${{ matrix.python-version }}-config --ldflags
-          python${{ matrix.python-version }}-config --cflags
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           python -m pip install --upgrade setuptools
           python -m pip install tox
       - name: Test
-          # For the Python 3.5 and 3.7 distributions on macOS in GitHub Actions,
-          # python-config --ldflags refuses to print a -L directive. We work around
-          # that with the LIBRARY_PATH variable below.
         env:
           PKG_CONFIG_PATH: ${{ env.pythonLocation }}/lib/pkgconfig/
         run: |
-          PYTHON_CONFIG=$(which python${{ matrix.python-version }}-config) LIBRARY_PATH="${{ env.pythonLocation }}/lib" tox -e py
+          PYTHON_CONFIG=$(which python${{ matrix.python-version }}-config) tox -e py
 
   # Test on x86 (32-bit) Ubuntu 18.04, focusing on 32-bit/64-bit errors; just one Python version.
   x86:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,17 +63,15 @@ jobs:
           export
           python${{ matrix.python-version }}-config --ldflags
           python${{ matrix.python-version }}-config --cflags
-      - name: Compile
-          # For the Python 3.5 and 3.7 distributions on macOS in GitHub Actions,
-          # python-config --ldflags refuses to print a -L directive. We work around
-          # that with the LIBRARY_PATH variable below.
-        run: PYTHON_CONFIG="python${{ matrix.python-version }}-config" LIBRARY_PATH="${{ env.pythonLocation }}/lib" make
-        env:
-          PKG_CONFIG_PATH: ${{ env.pythonLocation }}/lib/pkgconfig/
-      - name: Debugging - Show dynamic linker information for librubicon.so
-        run: LD_LIBRARY_PATH="${{ env.pythonLocation }}/lib" ldd build/librubicon.so || otool -L build/librubicon.dylib
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --upgrade setuptools
+          python -m pip install tox
       - name: Test
-        run: RUBICON_LIBRARY="${PWD}/build/librubicon.${{ runner.os == 'Linux' && 'so' || 'dylib' }}" ${{ runner.os == 'Linux' && 'LD_' || 'DYLD_' }}LIBRARY_PATH="${{env.pythonLocation}}/lib:$(pwd)/build" java org.beeware.rubicon.test.Test
+        run: |
+          tox -e py
+
 
   # Now test on all recent versions of Python as well.
   python-versions:
@@ -102,17 +100,14 @@ jobs:
           export
           python${{ matrix.python-version }}-config --ldflags
           python${{ matrix.python-version }}-config --cflags
-      - name: Compile
-          # For the Python 3.5 and 3.7 distributions on macOS in GitHub Actions,
-          # python-config --ldflags refuses to print a -L directive. We work around
-          # that with the LIBRARY_PATH variable below.
-        run: PYTHON_CONFIG="python${{ matrix.python-version }}-config" LIBRARY_PATH="${{ env.pythonLocation }}/lib" make
-        env:
-          PKG_CONFIG_PATH: ${{ env.pythonLocation }}/lib/pkgconfig/
-      - name: Debugging - Show dynamic linker information for librubicon.so
-        run: LD_LIBRARY_PATH="${{ env.pythonLocation }}/lib" ldd build/librubicon.so || otool -L build/librubicon.dylib
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --upgrade setuptools
+          python -m pip install tox
       - name: Test
-        run: RUBICON_LIBRARY="${PWD}/build/librubicon.${{ runner.os == 'Linux' && 'so' || 'dylib' }}" ${{ runner.os == 'Linux' && 'LD_' || 'DYLD_' }}LIBRARY_PATH="${{env.pythonLocation}}/lib:$(pwd)/build" java org.beeware.rubicon.test.Test
+        run: |
+          tox -e py
 
   # Test on x86 (32-bit) Ubuntu 18.04, focusing on 32-bit/64-bit errors; just one Python version.
   x86:

--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ build/librubicon.$(SOEXT): jni/rubicon.o
 	mkdir -p build
 	$(CC) -shared -o $@ $< $(LDFLAGS)
 
-PYTHON_LIBS_DIR := $(shell echo `dirname $(PYTHON_CONFIG)`/../Lib)
+PYTHON_LIBS_DIR := $(shell echo `dirname $(PYTHON_CONFIG)`/../lib)
 
 test: all
 # Rather than test which OS we're on, we set the Mac DYLD_LIBRARY_PATH as

--- a/README.rst
+++ b/README.rst
@@ -143,26 +143,30 @@ Testing
 
 To run the Rubicon test suite:
 
-1. Configure your shell environment to point to a ``PYTHON_CONFIG`` binary.
-   `virtualenv` and `venv` do not necessarily put the ``python3-config`` binary
-   on your ``$PATH``, but you can use this expression to set it properly::
+1. Check if `python-config` passes exists in your environment, and points at
+   your current active Python 3 install. You can confirm this by running::
 
-    $ export PYTHON_CONFIG="$(python3 -c 'import sys; from pathlib import Path; print(str(Path(sys.executable).resolve()) + "-config")')"
+       $ python-config --prefix
+
+   and confirming that the path points at the same Python that you're using.
+   If it doesn't, set a ``PYTHON_CONFIG`` environment variable::
+
+       $ export PYTHON_CONFIG="$(python3 -c 'import sys; from pathlib import Path; print(str(Path(sys.executable).resolve()) + "-config")')"
 
 2. Ensure that ``java`` is on your ``$PATH``, or set the ``JAVA_HOME`` environment
    variable to point to a directory of a Java Development Kit (JDK).
 
-3. Build the libraries::
+3. Install ``tox``::
 
-    $ make clean
-    $ make all
+    $ pip install tox
 
 4. Run the test suite. The following should work properly on both macOS and
    Linux::
 
-    $ make test
+    $ tox -e py
 
-This is a Python test suite, invoked via Java.
+This will compile the Rubicon library, compile the Java test classes, and
+run the Python test suite from within the Java environment.
 
 Documentation
 -------------

--- a/docs/how-to/contribute-code.rst
+++ b/docs/how-to/contribute-code.rst
@@ -29,6 +29,20 @@ coding:
     (venv) $ cd rubicon-objc
     (venv) $ pip install -e .
 
+Next, check if `python-config` passes exists in your environment, and points at
+your current active Python 3 install. You can confirm this by running:
+
+.. code-block:: sh
+
+   (venv) $ python-config --prefix
+
+and checking that the path points at the same Python that you're using. If it
+doesn't, set a ``PYTHON_CONFIG`` environment variable:
+
+.. code-block:: sh
+
+    (venv) $ export PYTHON_CONFIG="$(python3 -c 'import sys; from pathlib import Path; print(str(Path(sys.executable).resolve()) + "-config")')"
+
 You can then run the full test suite:
 
 .. code-block:: sh

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,7 @@ whitelist_externals =
 passenv =
     PYTHON_CONFIG
     JAVA_HOME
+    LIBRARY_PATH
 commands =
     make clean
     make all

--- a/tox.ini
+++ b/tox.ini
@@ -12,9 +12,9 @@ whitelist_externals =
     make
     java
 passenv =
-    PYTHON_CONFIG
     JAVA_HOME
     LIBRARY_PATH
+    PYTHON_CONFIG
 commands =
     make clean
     make all


### PR DESCRIPTION
Now that we have a `tox.ini`, we can use it as a central point of configuration shared between dev and CI environments.