### PR TITLE
Stop setting Python configuration options in Python.init()

### DIFF
--- a/changes/45.misc.rst
+++ b/changes/45.misc.rst
@@ -1,3 +1,1 @@
-Stopped configuring two Python features by environment variable (unbuffered I/O
-& no writing of bytecode). Callers of ``Python.init()`` can set environment
-variables to their pleasure.
+Bytecode writing and buffered I/O are no longer explicitly disabled on initialization. These features can be re-enabled by setting the ``PYTHONDONTWRITEBYTECODE`` and ``PYTHONUNBUFFERED`` environment variables, respectively.

--- a/changes/45.misc.rst
+++ b/changes/45.misc.rst
@@ -1,0 +1,3 @@
+Stopped configuring two Python features by environment variable (unbuffered I/O
+& no writing of bytecode). Callers of ``Python.init()`` can set environment
+variables to their pleasure.

--- a/jni/rubicon.c
+++ b/jni/rubicon.c
@@ -842,13 +842,6 @@ JNIEXPORT jint JNICALL Java_org_beeware_rubicon_Python_init(JNIEnv *env, jobject
     dlopen(LIBPYTHON_RTLD_GLOBAL, RTLD_LAZY | RTLD_GLOBAL);
 #endif
 
-    // To avoid the possibility of permissions errors writing *.pyc files
-    // in permission-constrained app environments, do not write compiled bytecode to disk.
-    putenv("PYTHONDONTWRITEBYTECODE=1");
-    // Set stdout and stderr to be unbuffered; this is helpful on Android, where we
-    // are overriding stdout & stderr and would prefer to avoid delays.
-    putenv("PYTHONUNBUFFERED=1");
-
     if (pythonHome) {
         LOG_D("PYTHONHOME=%s", (*env)->GetStringUTFChars(env, pythonHome, NULL));
         const char *python_home;


### PR DESCRIPTION
If someone really wants to disable this, they can call `putenv()`
themselves before calling `Python.start()`.

## Testing performed

None, other than running the automated tests.

If we need to "revert" this, we can do it in the template.