### PR TITLE
Rely on Python 3.3+ automatic namespace packages (PEP 420)

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -9,6 +9,7 @@ include docs/Makefile
 include docs/make.bat
 include docs/requirements_docs.txt
 include docs/spelling_wordlist
+recursive-include rubicon/java *.py
 recursive-include docs *.png *.py *.rst
 prune docs/_build
 recursive-include jni *.h *.c *.mk

--- a/changes/46.misc.rst
+++ b/changes/46.misc.rst
@@ -1,0 +1,1 @@
+Remove rubicon/__init__.py in order to rely on Python 3.3+ namespace package system (PEP 420)

--- a/rubicon/__init__.py
+++ b/rubicon/__init__.py
@@ -1,9 +1,0 @@
-from __future__ import print_function
-
-try:
-    # If we're on Android, we won't have pkg-resources; but then,
-    # we won't need to register the namespace package, either.
-    # Ignore the error if it occurs.
-    __import__("pkg_resources").declare_namespace(__name__)
-except ImportError:
-    print('Rubicon namespace package not registered!')


### PR DESCRIPTION
I ran into this unnecessary import while auditing rubicon-java for unnecessary imports as part of looking into Python Android app startup speed.

The test suite shows that this is a peaceful change. In addition, this transcript shows it works properly, I believe.

```
$ python3
Python 3.7.7 (default, Jun 12 2020, 22:00:17) 
[Clang 11.0.3 (clang-1103.0.32.62)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import rubicon
>>> rubicon
<module 'rubicon' (namespace)>
>>> import rubicon.java
>>> rubicon.java
<module 'rubicon.java' from '/Users/paulproteus/projects/beeware/rubicon-java/rubicon/java/__init__.py'>
>>> 
```

See also https://www.python.org/dev/peps/pep-0420/