### PR TITLE
Rely on RUBICON_LIBRARY env var, for speed

### DIFF
--- a/changes/47.misc.rst
+++ b/changes/47.misc.rst
@@ -1,0 +1,2 @@
+Only call ``ctypes.util.find_library()`` if ``RUBICON_LIBRARY`` is absent
+from the environment. This allows a rubicon-java user to pick the fast path.


### PR DESCRIPTION
For a Toga/Briefcase app with Android, this improves second-time app startup by a few hundred milliseconds on my virtual device, which is quite significant IMHO.

Before: approx 0.9 seconds for `import rubicon.java` (that's what `Python.init()` does)

```
06-29 02:07:03.664 15839 15839 D MainActivity: unpackPython() complete
06-29 02:07:04.585 15839 15839 D MainActivity: Python.init() complete
```

After: approx 0.3 seconds for the same

```
06-29 02:05:37.622 15770 15770 D MainActivity: unpackPython() complete
06-29 02:05:37.913 15770 15770 D MainActivity: Python.init() complete
```

My measurements remain noisy, but this one seems decently reliable in my testing. I tried other tweaks that weren't reliably helpful, so I hope you'll accept this one. :)