### PR TITLE
Simplify namespace package metadata

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -9,7 +9,6 @@ include docs/Makefile
 include docs/make.bat
 include docs/requirements_docs.txt
 include docs/spelling_wordlist
-recursive-include rubicon/java *.py
 recursive-include docs *.png *.py *.rst
 prune docs/_build
 recursive-include jni *.h *.c *.mk

--- a/changes/48.misc.rst
+++ b/changes/48.misc.rst
@@ -1,0 +1,1 @@
+Further simplified namespace package metadata in setup.cfg.

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,14 +29,9 @@ long_description_content_type = text/x-rst
 
 [options]
 python_requires = >=3.5
-packages = find:
+packages = rubicon.java
 namespace_packages =
     rubicon
-
-[options.packages.find]
-include =
-    rubicon
-    rubicon.*
 
 [flake8]
 # https://flake8.readthedocs.org/en/latest/


### PR DESCRIPTION
This fixes a bug where the files were being included in the
sdist, but they weren't available if you 'pip install' the
package, so therefore apps wouldn't launch.