### PR TITLE
Add I/O handling in event loop

### DIFF
--- a/changes/49.feature.rst
+++ b/changes/49.feature.rst
@@ -1,1 +1,1 @@
-Added I/O integration to cooperate with Android event loop.
+AsyncIO network operations are now integrated with the Android event loop.

--- a/changes/49.feature.rst
+++ b/changes/49.feature.rst
@@ -1,0 +1,1 @@
+Added I/O integration to cooperate with Android event loop.

--- a/rubicon/java/android_events.py
+++ b/rubicon/java/android_events.py
@@ -424,6 +424,7 @@ def _create_java_fd(int_fd):
     """Given a numeric file descriptor, create a `java.io.FileDescriptor` object."""
     # On Android, the class exposes hidden (non-private) methods `getInt$()` and `setInt$()`. Because
     # they aren't valid Python identifier names, we need to use `getattr()` to grab them.
+    # noqa: E501
     # See e.g. https://android.googlesource.com/platform/prebuilts/fullsdk/sources/android-28/+/refs/heads/master/java/io/FileDescriptor.java#149
     java_fd = FileDescriptor()
     getattr(java_fd, "setInt$")(int_fd)

--- a/rubicon/java/android_events.py
+++ b/rubicon/java/android_events.py
@@ -424,8 +424,7 @@ def _create_java_fd(int_fd):
     """Given a numeric file descriptor, create a `java.io.FileDescriptor` object."""
     # On Android, the class exposes hidden (non-private) methods `getInt$()` and `setInt$()`. Because
     # they aren't valid Python identifier names, we need to use `getattr()` to grab them.
-    # noqa: E501
-    # See e.g. https://android.googlesource.com/platform/prebuilts/fullsdk/sources/android-28/+/refs/heads/master/java/io/FileDescriptor.java#149
+    # See e.g. https://android.googlesource.com/platform/prebuilts/fullsdk/sources/android-28/+/refs/heads/master/java/io/FileDescriptor.java#149 # noqa: E501
     java_fd = FileDescriptor()
     getattr(java_fd, "setInt$")(int_fd)
     return java_fd

--- a/rubicon/java/android_events.py
+++ b/rubicon/java/android_events.py
@@ -263,7 +263,7 @@ class AndroidSelector(selectors.SelectSelector):
     """Subclass of selectors.Selector which cooperates with the Android event loop
     to learn when file descriptors become ready for I/O.
 
-    It lacks a `select()` function to avoid blocking."""
+    AndroidSelector's `select()` raises NotImplementedError; see its comments."""
 
     def __init__(self, loop):
         super().__init__()


### PR DESCRIPTION
To test, use the following sample code in e.g. `app.py`.

```
import toga
from toga.style import Pack
from toga.style.pack import COLUMN, ROW

import asyncio
import rubicon.java.android_events

class PerfTest(toga.App):
    def startup(self):
        main_box = toga.Box(style=Pack(direction=COLUMN))

        name_label = toga.Label("Your name: ", style=Pack(padding=(0, 5)))
        self.name_input = toga.TextInput(style=Pack(flex=1))

        name_box = toga.Box(style=Pack(direction=ROW, padding=5))
        name_box.add(name_label)
        name_box.add(self.name_input)

        button = toga.Button(
            "Say Hello!", on_press=self.say_hello, style=Pack(padding=5)
        )

        main_box.add(name_box)
        main_box.add(button)

        self.main_window = toga.MainWindow(title=self.formal_name)
        self.main_window.content = main_box
        self.main_window.show()

        # Start asyncio
        self.loop = rubicon.java.android_events.AndroidEventLoop()
        self.loop.run_forever_cooperatively()
        print('loop started, self.loop ' + str(self.loop))

        # Immediately run a sleep(0) task that prints 'sleep works'
        async def say_sleep_works():
            await asyncio.sleep(0)
            print('sleep works')
            reader, writer = await asyncio.open_connection("echo.u-blox.com", 7)
            writer.write(b"hi")
            await writer.drain()
            data = await reader.read(100)
            if b'hi' not in data:
                data += await reader.read(100)
            print(f"Received: {data.decode()!r}")
            name_label.text = data.decode()
            await asyncio.sleep(1)
            print('sleep works twice')
            await asyncio.sleep(0)
            writer.close()
            await writer.wait_closed()
            print('closed')
            import aiohttp
            import json
            async with aiohttp.ClientSession() as session:
                async with session.get('https://api.ipify.org/?format=json') as resp:
                    print('http status = ' + str(resp.status))
                    if str(resp.status) == '200':
                        name_label.text = json.loads(await resp.text())['ip']


        asyncio.ensure_future(say_sleep_works())

    def say_hello(self, widget):
        print("Hello from say_hello!")


def main():
    return PerfTest()

```

and add `aiohttp` to `pyproject.toml` within `requires`.

## Testing performed

The event loop works. It's shocking. OK, maybe I shouldn't be shocked.

Here's a screenshot. The app doesn't lock up while waiting.

![Screen Shot 2020-06-30 at 9 16 17 PM](https://user-images.githubusercontent.com/25457/86202392-f1492a00-bb16-11ea-855e-83129d70b56d.png)
