### PR TITLE
Only use _set_coroutine_origin_tracking when it exists

### DIFF
--- a/changes/51.bugfix.rst
+++ b/changes/51.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed asyncio event loop startup on Python 3.6.

--- a/rubicon/java/android_events.py
+++ b/rubicon/java/android_events.py
@@ -122,6 +122,12 @@ class AndroidEventLoop(asyncio.SelectorEventLoop):
             self.run_delayed_tasks, timeout * 1000,
         )
 
+    def _set_coroutine_origin_tracking(self, debug):
+        # If running on Python 3.7 or 3.8, integrate with upstream event loop's debug feature, allowing
+        # unawaited coroutines to have some useful info logged. See https://bugs.python.org/issue32591
+        if hasattr(super(), "_set_coroutine_origin_tracking"):
+            super()._set_coroutine_origin_tracking(debug)
+
     def _get_next_delayed_task_wakeup(self):
         """Compute the time to sleep before we should be woken up to handle delayed tasks."""
         # This is based heavily on the CPython's implementation of `BaseEventLoop._run_once()`


### PR DESCRIPTION
This is a pretty minimal patch that is 3.7/3.8+ oriented. It means that on Python 3.6, if users' app has a situation where they create a coroutine but never call await() on it, then Python won't print its helpful message along the lines of, "You created a coroutine, but no one called await() on it." Users can get the warning on Python 3.7/3.8 still if they set a `debug` flag in this file, or in `toga` when it starts the event loop, or (I think) while the event loop is running by accessing the loop object.

I think this is a good implementation priorities choice, but I wanted to mention that in case it's controversial.

We don't really have Android CI, but note that this is a case where testing on an emulated environment would basically definitely be fine for running a test of this functionality; real device wouldn't really be needed IMHO. I didn't write an automated test because we don't currently have a great way to run them.

Close #50

I've tested that apps start up properly on Python 3.6 and Python 3.7.

Thanks to @sulabh9999 and @Garrapata-Piletera for getting in touch about the issue on https://github.com/beeware/briefcase/issues/454 .

## PR Checklist:
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
