### PR TITLE
Add support for implementing Java interfaces that return bool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ build/rubicon.jar: org/beeware/rubicon/Python.class org/beeware/rubicon/PythonIn
 	mkdir -p build
 	jar -cvf build/rubicon.jar org/beeware/rubicon/Python.class org/beeware/rubicon/PythonInstance.class
 
-build/test.jar: org/beeware/rubicon/test/BaseExample.class org/beeware/rubicon/test/Example.class org/beeware/rubicon/test/ICallback.class org/beeware/rubicon/test/ICallbackInt.class org/beeware/rubicon/test/AddOne.class org/beeware/rubicon/test/AbstractCallback.class org/beeware/rubicon/test/Thing.class org/beeware/rubicon/test/Test.class
+build/test.jar: org/beeware/rubicon/test/BaseExample.class org/beeware/rubicon/test/Example.class org/beeware/rubicon/test/ICallback.class org/beeware/rubicon/test/ICallbackBool.class org/beeware/rubicon/test/ICallbackInt.class org/beeware/rubicon/test/AddOne.class org/beeware/rubicon/test/TruthInverter.class org/beeware/rubicon/test/AbstractCallback.class org/beeware/rubicon/test/Thing.class org/beeware/rubicon/test/Test.class
 	mkdir -p build
 	jar -cvf build/test.jar org/beeware/rubicon/test/*.class
 

--- a/changes/52.feature.rst
+++ b/changes/52.feature.rst
@@ -1,0 +1,1 @@
+Added support for implementing Java interfaces that return ``bool``.

--- a/org/beeware/rubicon/test/ICallbackBool.java
+++ b/org/beeware/rubicon/test/ICallbackBool.java
@@ -1,0 +1,6 @@
+package org.beeware.rubicon.test;
+
+
+public interface ICallbackBool {
+    public boolean getBool();
+}

--- a/org/beeware/rubicon/test/TruthInverter.java
+++ b/org/beeware/rubicon/test/TruthInverter.java
@@ -1,0 +1,7 @@
+package org.beeware.rubicon.test;
+
+public class TruthInverter {
+    public boolean invert(ICallbackBool bool_maker) {
+        return !(bool_maker.getBool());
+    }
+}

--- a/tests/test_rubicon.py
+++ b/tests/test_rubicon.py
@@ -379,6 +379,29 @@ class JNITest(TestCase):
         # Validate that implementation mutates example1's state, not example2's state.
         self.assertEqual(35, AddOne().addOne(implementation, example2))
 
+    def test_interface_bool_return(self):
+        """A Java interface with a bool-returning method can be defined in Python and proxied,
+        including return value."""
+        ICallbackBool = JavaInterface('org/beeware/rubicon/test/ICallbackBool')
+
+        class MakeBool(ICallbackBool):
+            def __init__(self, s):
+                super().__init__()
+                self.s = s
+
+            def getBool(self):
+                if self.s == "yes":
+                    return True
+                return False
+
+        true_maker = MakeBool("yes")
+        false_maker = MakeBool("no")
+
+        # Validate that a Java class can use our Python class when expecting the bool-returning interface.
+        TruthInverter = JavaClass("org/beeware/rubicon/test/TruthInverter")
+        self.assertFalse(TruthInverter().invert(true_maker))
+        self.assertTrue(TruthInverter().invert(false_maker))
+
     def test_alternatives(self):
         "A class is aware of it's type hierarchy"
         Example = JavaClass('org/beeware/rubicon/test/Example')


### PR DESCRIPTION
Add support for implementing Java interfaces that return `bool`. (I need this for Android `onTouch` in `View.OnTouchListener`.)

## PR Checklist:
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
