### PR TITLE
Refs #58 - Allow for typed NULLs in Java calls

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,9 @@ PYTHON_VERSION := $(shell echo ${PYTHON_LDVERSION} | sed 's,[^0-9.],,g')
 # Use CFLAGS and LDFLAGS based on Python's. We add -fPIC since we're creating a
 # shared library, and we remove -stack_size (only seen on macOS), since it only
 # applies to executables.
-CFLAGS := $(shell $(PYTHON_CONFIG) --cflags) -fPIC
+# -Wno-nullability-completeness and -Wno-expansion-to-defined silence warnings that
+# are raised by the C library itself.
+CFLAGS := $(shell $(PYTHON_CONFIG) --cflags) -fPIC -Wno-nullability-completeness -Wno-expansion-to-defined
 LDFLAGS := $(shell $(PYTHON_CONFIG) --ldflags ${PYTHON_CONFIG_EXTRA_FLAGS} | sed 'sX-Wl,-stack_size,1000000XXg')
 
 # If we are compiling for Android, the C code will detect it via #define. We need to accommodate

--- a/changes/63.feature.rst
+++ b/changes/63.feature.rst
@@ -1,1 +1,1 @@
-``None`` can now be passed as an argument where a Java ``NULL`` would be legal.
+Methods that accept a Java ``NULL`` as an argument are now supported.

--- a/changes/63.feature.rst
+++ b/changes/63.feature.rst
@@ -1,0 +1,1 @@
+``None`` can now be passed as an argument where a Java ``NULL`` would be legal.

--- a/org/beeware/rubicon/test/Example.java
+++ b/org/beeware/rubicon/test/Example.java
@@ -171,17 +171,33 @@ public class Example extends BaseExample {
     }
 
     /* Handling long argument lists */
-    public String combiner(int x, String name, Thing thing) {
+    public String combiner(int x, String name, Thing thing, ICallback callback, int [] values) {
         if (name == null) {
-            if (thing == null) {
-                return x + ":: No special name or thing";
-            } else {
-                return x + ":: No special name ::" + thing;
-            }
-        } else if (thing == null) {
-            return x + "::" + name + " (but no thing)";
+            name = "<no special name>";
         }
-        return x + "::" + name + "::" + thing;
+
+        String thing_label;
+        if (thing == null) {
+            thing_label = "<no special thing>";
+        } else {
+            thing_label = thing.toString();
+        }
+
+        String callback_label;
+        if (callback == null) {
+            callback_label = "<no callback>";
+        } else {
+            callback_label = "There is a callback";
+        }
+
+        String value_count;
+        if (values == null) {
+            value_count = "<no values to count>";
+        } else {
+            value_count = "There are " + values.length + " values";
+        }
+
+        return x + "::" + name + "::" + thing_label + "::" + callback_label + "::" + value_count;
     }
 
     /* Interface visiblity */

--- a/org/beeware/rubicon/test/Example.java
+++ b/org/beeware/rubicon/test/Example.java
@@ -144,6 +144,9 @@ public class Example extends BaseExample {
 
     /* Polymorphism handling */
     public String doubler(String in) {
+        if (in == null) {
+            return "Can't double NULL strings";
+        }
         return in + in;
     }
 
@@ -165,6 +168,20 @@ public class Example extends BaseExample {
 
     public static long tripler(long in) {
         return in + in + in;
+    }
+
+    /* Handling long argument lists */
+    public String combiner(int x, String name, Thing thing) {
+        if (name == null) {
+            if (thing == null) {
+                return x + ":: No special name or thing";
+            } else {
+                return x + ":: No special name ::" + thing;
+            }
+        } else if (thing == null) {
+            return x + "::" + name + " (but no thing)";
+        }
+        return x + "::" + name + "::" + thing;
     }
 
     /* Interface visiblity */

--- a/rubicon/java/api.py
+++ b/rubicon/java/api.py
@@ -125,7 +125,7 @@ def convert_args(args, type_names):
             converted.append(java.NewStringUTF(arg.encode('utf-8')))
         elif isinstance(arg, (JavaInstance, JavaProxy)):
             converted.append(arg.__jni__)
-        elif arg is None:
+        elif isinstance(arg, JavaNull):
             converted.append(None)
         else:
             raise ValueError("Unknown argument type", arg, type(arg))
@@ -156,10 +156,9 @@ def select_polymorph(polymorphs, args):
        to polymorphs[match_types]
     """
     arg_types = []
-    has_null_arg = False
     if len(args) == 0:
         arg_sig = b''
-        options = [()]
+        options = [[]]
     else:
         for arg in args:
             if isinstance(arg, (bool, jboolean)):
@@ -215,54 +214,21 @@ def select_polymorph(polymorphs, args):
                     raise ValueError("Unable convert sequence into array of Java primitive types")
             elif isinstance(arg, (JavaInstance, JavaProxy)):
                 arg_types.append(arg.__class__.__dict__['_alternates'])
-            elif arg is None:
-                # Insert a placeholder that won't match any polymorph literally,
-                # but can be matched individually.
-                arg_types.append([b'<null>'])
-                has_null_arg = True
+            elif isinstance(arg, JavaNull):
+                arg_types.append([arg._signature])
             else:
                 raise ValueError("Unknown argument type", arg, type(arg))
 
         arg_sig = b''.join(t[0] for t in arg_types)
         options = list(itertools.product(*arg_types))
 
-    if not has_null_arg:
-        # Try all the possible interpretations of the arguments
-        # as polymorphic forms.
-        for option in options:
-            try:
-                return option, polymorphs[option]
-            except KeyError:
-                pass
-    else:
-        # If there's a null argument, we can't do a literal lookup -
-        # we need to start with the polymorphs, and look for any
-        # method that could match, using the nulls as wildcards
-        # for class references.
-        matches = {}
-        for polymorph_arg_types, polymorph in polymorphs.items():
-            # Only consider candidates that have the same number of arguments
-            if len(polymorph_arg_types) == len(arg_types):
-                for option in options:
-                    # Iterate over all the options; if all the arguments match
-                    #
-                    if all(
-                        arg_type == polymorph_arg_type
-                        or (arg_type == b'<null>' and polymorph_arg_type.startswith(b'L'))
-                        for arg_type, polymorph_arg_type in zip(option, polymorph_arg_types)
-                    ):
-                        matches[polymorph_arg_types] = polymorph
-
-        if len(matches) == 1:
-            return list(matches.items())[0]
-        else:
-            # Found more than one match.
-            # TODO: This *could* be resolved; JLS 15.12.2.5
-            # https://docs.oracle.com/javase/specs/jls/se7/html/jls-15.html#jls-15.12.2.5
-            # says the "most specific" class reference should win.
-            # However, in practice, this doesn't happen that often,
-            # so raise an error for now.
-            KeyError(arg_sig)
+    # Try all the possible interpretations of the arguments
+    # as polymorphic forms.
+    for option in options:
+        try:
+            return option, polymorphs[b''.join(option)]
+        except KeyError:
+            pass
 
     raise KeyError(arg_sig)
 
@@ -322,12 +288,12 @@ def type_names_for_params(params):
     return tuple(sig)
 
 
-def signature_for_type_names(type_names):
+def signature_for_params(params):
     """Determine the JNI-style signature string for an array of Java parameters.
     This is used to convert a Method declaration into a string signature
     that can be used for later lookup.
     """
-    return b''.join(type_names)
+    return b''.join(type_names_for_params(params))
 
 
 def return_cast(raw, return_signature):
@@ -431,8 +397,8 @@ class StaticJavaMethod(object):
         self.name = name
         self._polymorphs = {}
 
-    def add(self, param_type_names, return_signature):
-        if param_type_names not in self._polymorphs:
+    def add(self, params_signature, return_signature):
+        if params_signature not in self._polymorphs:
             invoker = {
                 b'V': java.CallStaticVoidMethod,
                 b'Z': java.CallStaticBooleanMethod,
@@ -445,7 +411,7 @@ class StaticJavaMethod(object):
                 b'D': java.CallStaticDoubleMethod,
             }.get(return_signature, java.CallStaticObjectMethod)
 
-            full_signature = b'(%s)%s' % (signature_for_type_names(param_type_names), return_signature)
+            full_signature = b'(%s)%s' % (params_signature, return_signature)
             jni = java.GetStaticMethodID(
                 self.java_class.__dict__['__jni__'],
                 self.name.encode('utf-8'),
@@ -458,7 +424,7 @@ class StaticJavaMethod(object):
                     full_signature.decode('utf-8'))
                 )
 
-            self._polymorphs[param_type_names] = {
+            self._polymorphs[params_signature] = {
                 'return_signature': return_signature,
                 'invoker': invoker,
                 'jni': jni
@@ -480,8 +446,8 @@ class StaticJavaMethod(object):
                     self.name,
                     e,
                     ', '.join(
-                        signature_for_type_names(type_names).decode('utf-8')
-                        for type_names in self._polymorphs.keys()
+                        params_signature.decode('utf-8')
+                        for params_signature in self._polymorphs.keys()
                     )
                 )
             )
@@ -493,7 +459,7 @@ class JavaMethod:
         self.name = name
         self._polymorphs = {}
 
-    def add(self, param_type_names, return_signature):
+    def add(self, params_signature, return_signature):
         invoker = {
             b'V': java.CallVoidMethod,
             b'Z': java.CallBooleanMethod,
@@ -506,7 +472,7 @@ class JavaMethod:
             b'D': java.CallDoubleMethod,
         }.get(return_signature, java.CallObjectMethod)
 
-        full_signature = b'(%s)%s' % (signature_for_type_names(param_type_names), return_signature)
+        full_signature = b'(%s)%s' % (params_signature, return_signature)
         jni = java.GetMethodID(
             self.java_class.__dict__['__jni__'],
             self.name.encode('utf-8'),
@@ -519,7 +485,7 @@ class JavaMethod:
                 full_signature.decode('utf-8')
             ))
 
-        self._polymorphs[param_type_names] = {
+        self._polymorphs[params_signature] = {
             'return_signature': return_signature,
             'invoker': invoker,
             'jni': jni
@@ -541,8 +507,8 @@ class JavaMethod:
                     self.name,
                     e,
                     ', '.join(
-                        signature_for_type_names(type_names).decode('utf-8')
-                        for type_names in self._polymorphs.keys()
+                        params_signature.decode('utf-8')
+                        for params_signature in self._polymorphs.keys()
                     )
                 )
             )
@@ -731,7 +697,7 @@ def _cache_methods(java_class, name, is_static):
             type_name = java.CallObjectMethod(java_type, reflect.Class__getName)
             return_type_name = java.GetStringUTFChars(cast(type_name, jstring), None)
 
-            wrapper.add(type_names_for_params(params), signature_for_type_name(return_type_name))
+            wrapper.add(signature_for_params(params), signature_for_type_name(return_type_name))
             java.DeleteLocalRef(type_name)
             java.DeleteLocalRef(java_type)
             java.DeleteLocalRef(params)
@@ -793,9 +759,9 @@ class JavaInstance(object):
 
                         # print("  %s: registering '%s' constructor " % (
                         #     self.__class__.__dict__['_descriptor'],
-                        #     type_names_for_params(params)
+                        #     signature_for_params(params)
                         # ))
-                        constructors[type_names_for_params(params)] = None
+                        constructors[signature_for_params(params)] = None
                     # else:
                         # print("  %s: ignoring nonpublic constructor" % self.__class__.__dict__['_descriptor'])
 
@@ -810,7 +776,7 @@ class JavaInstance(object):
             try:
                 match_types, constructor = select_polymorph(constructors, args)
                 if constructor is None:
-                    sig = signature_for_type_names(match_types)
+                    sig = b''.join(match_types)
                     constructor = java.GetMethodID(
                         klass,
                         b'<init>',
@@ -821,7 +787,7 @@ class JavaInstance(object):
                             sig.decode('utf-8'),
                             self.__class__
                         ))
-                    self.__class__.__dict__['_constructors'][match_types] = constructor
+                    self.__class__.__dict__['_constructors'][sig] = constructor
 
                 jni = java.NewObject(klass, constructor, *convert_args(args, match_types))
                 if not jni:
@@ -835,8 +801,8 @@ class JavaInstance(object):
                     "Can't find constructor matching argument signature %s. Options are: %s" % (
                         e,
                         ', '.join(
-                            signature_for_type_names(type_names).decode('utf-8')
-                            for type_names in constructors.keys()
+                            params_signature.decode('utf-8')
+                            for params_signature in constructors.keys()
                         )
                     )
                 )
@@ -914,6 +880,105 @@ class UnknownClassException(Exception):
         return "Couldn't find Java class '%s'" % self.descriptor
 
 
+class JavaNull:
+    def __init__(self, type_or_signature):
+        """
+        A "typed NULL"; a value that will evaluate as a Java NULL when used
+        as argument, but carries an explicit signature for type matching
+        purposes.
+
+        This can be constructed explicitly using a JNI type signature:
+
+            JavaNull(b'Lcom/example/Thing;')
+
+        or inferred from a JavaClass
+
+            Thing = JavaClass('com/example/Thing')
+            JavaNull(Thing)
+
+        or from a Python primitive:
+
+            JavaNull(str)
+
+        or from a JNI primitive:
+
+            JavaNull(jdouble)
+
+        Array arguments can be constructed by passing in a list with a
+        single item; the item being one of the previous inferred types:
+
+            JavaNull([b'Lcom/example/Thing;'])
+            JavaNull([Thing])
+            JavaNull([str])
+            JavaNull([jdouble])
+
+        """
+        if isinstance(type_or_signature, bytes):
+            self._signature = type_or_signature
+        else:
+            try:
+                # If the object has a predefined typed NULL, use it
+                self._signature = type_or_signature.__null__._signature
+            except AttributeError:
+                # If the object is a list, try to convert into an array type
+                # The array *must* have exactly 1 element, and the element
+                # is the type of the array NULL to construct.
+                if isinstance(type_or_signature, Sequence):
+                    if len(type_or_signature) == 1:
+                        try:
+                            self._signature = b'[' + type_or_signature[0].__null__._signature
+                        except AttributeError:
+                            try:
+                                self._signature = {
+                                    bool: b'[Z',
+                                    jboolean: b'[Z',
+                                    jbyte: b'[B',
+                                    jchar: b'[C',
+                                    jshort: b'[S',
+                                    int: b'[I',
+                                    jint: b'[I',
+                                    jlong: b'[J',
+                                    float: b'[F',
+                                    jfloat: b'[F',
+                                    jdouble: b'[D',
+                                    str: b"[Ljava/lang/String;",
+                                    jstring: b"[Ljava/lang/String;",
+                                }[type_or_signature[0]]
+                            except (TypeError, KeyError):
+                                if isinstance(type_or_signature[0], bytes):
+                                    self._signature = self._signature = b'[' + type_or_signature[0]
+                                else:
+                                    raise ValueError(
+                                        "Cannot create a typed null for an array of {}".format(
+                                            type_or_signature[0]
+                                        )
+                                    )
+                    else:
+                        raise ValueError("Typed nulls for an array must contain a single item")
+                else:
+                    # Is the object a primitive type (or JNI type)?
+                    # If so, convert it directly to a type signature.
+                    try:
+                        self._signature = {
+                            bool: b'Z',
+                            jboolean: b'Z',
+                            jbyte: b'B',
+                            jchar: b'C',
+                            jshort: b'S',
+                            int: b'I',
+                            jint: b'I',
+                            jlong: b'J',
+                            float: b'F',
+                            jfloat: b'F',
+                            jdouble: b'D',
+                            str: b"Ljava/lang/String;",
+                            jstring: b"Ljava/lang/String;",
+                            bytes: b'[B',
+                        }[type_or_signature]
+                    except KeyError:
+                        raise ValueError("Cannot create a typed null for {!r}".format(type_or_signature))
+
+
 class JavaClass(type):
     # This class returns known JavaClass instances where possible.
     _class_cache = {}
@@ -988,6 +1053,7 @@ class JavaClass(type):
             {
                 '_descriptor': descriptor_bytes,
                 '__jni__': jni,
+                '__null__': JavaNull(alternates[0]),
                 '_alternates': alternates,
                 '_constructors': None,
                 '_members': {
@@ -1104,13 +1170,15 @@ class JavaInterface(type):
         if len(args) == 1:
             descriptor = args[0].encode('utf-8')
             # print("Creating Java Interface " + descriptor)
+            alternates = [b'L%s;' % descriptor]
             java_class = super(JavaInterface, cls).__new__(
                 cls,
                 descriptor.decode('utf-8'),
                 (JavaProxy,),
                 {
                     '_descriptor': descriptor,
-                    '_alternates': ['L%s;' % descriptor],
+                    '__null__': JavaNull(alternates[0]),
+                    '_alternates': alternates,
                     '_methods': {}
                 }
             )
@@ -1118,8 +1186,10 @@ class JavaInterface(type):
             name, bases, attrs = args
             # print("Creating Java Interface " + bases[-1].__dict__['_descriptor'])
             descriptor = bases[-1].__dict__['_descriptor']
+            alternates = [b'L%s;' % descriptor]
             attrs['_descriptor'] = descriptor
-            attrs['_alternates'] = [b'L%s;' % descriptor]
+            attrs['__null__'] = JavaNull(alternates[0])
+            attrs['_alternates'] = alternates
             attrs['_methods'] = {}
             java_class = super(JavaInterface, cls).__new__(cls, name, bases, attrs)
 

--- a/rubicon/java/api.py
+++ b/rubicon/java/api.py
@@ -1057,7 +1057,9 @@ class JavaClass(type):
         if field_wrapper:
             return field_wrapper.set(value)
 
-        raise AttributeError("Java class '%s' has no attribute '%s'" % (self.__dict__['_descriptor'].decode('utf-8'), name))
+        raise AttributeError("Java class '%s' has no attribute '%s'" % (
+            self.__dict__['_descriptor'].decode('utf-8'), name)
+        )
 
     def __repr__(self):
         return "<JavaClass: %s>" % self._descriptor.decode('utf-8')

--- a/setup.cfg
+++ b/setup.cfg
@@ -51,7 +51,8 @@ max-line-length = 119
 # E133: closing bracket missing indentation
 # E226: missing whitespace around arithmetic operator
 # W503: line break occurred before a binary operator
-ignore = E133,E226,W503
+# C901: Cyclomatic complexity is too high
+ignore = E133,E226,W503,C901
 
 [isort]
 combine_as_imports = true

--- a/tests/test_rubicon.py
+++ b/tests/test_rubicon.py
@@ -2,7 +2,7 @@ import math
 import sys
 from unittest import TestCase
 
-from rubicon.java import JavaClass, JavaInterface
+from rubicon.java import JavaClass, JavaInterface, JavaNull, jstring, jlong
 
 
 class JNITest(TestCase):
@@ -222,9 +222,6 @@ class JNITest(TestCase):
         self.assertEqual(obj1.doubler(42), 84)
         self.assertEqual(obj1.doubler("wibble"), "wibblewibble")
 
-        # None will be resolved to a matching polymorph
-        self.assertEqual(obj1.doubler(None), "Can't double NULL strings")
-
         # If arguments don't match available options, an error is raised
         with self.assertRaises(ValueError):
             obj1.doubler(1.234)
@@ -237,22 +234,123 @@ class JNITest(TestCase):
         Thing = JavaClass('org/beeware/rubicon/test/Thing')
         thing = Thing('This is thing', 2)
 
-        self.assertEqual(obj1.combiner(3, "Pork", thing), '3::Pork::This is thing 2')
-        self.assertEqual(obj1.combiner(3, None, thing), '3:: No special name ::This is thing 2')
-        self.assertEqual(obj1.combiner(3, "Pork", None), '3::Pork (but no thing)')
-        self.assertEqual(obj1.combiner(3, None, None), '3:: No special name or thing')
+        ICallback = JavaInterface('org/beeware/rubicon/test/ICallback')
 
-        # None can only be used when an object is expected.
-        with self.assertRaises(ValueError):
-            obj1.combiner(None, "Pork", thing)
+        class MyInterface(ICallback):
+            def poke(self, example, value):
+                pass
 
-        # Type mismatches are still a problem
-        with self.assertRaises(ValueError):
-            obj1.combiner(1.234, "Pork", thing)
+            def peek(self, example, value):
+                pass
 
-        # Argument count mismatches are still a problem
+        handler = MyInterface()
+
+        # An explicit typed NULL can be used to match None arguments.
+        self.assertEqual(
+            obj1.combiner(3, JavaNull(b'Ljava/lang/String;'), thing, handler, [1, 2]),
+            "3::<no special name>::This is thing 2::There is a callback::There are 2 values"
+        )
+
+        # A typed Null can be constructed from a primitive Python
+        self.assertEqual(
+            obj1.combiner(3, JavaNull(str), thing, handler, [1, 2]),
+            "3::<no special name>::This is thing 2::There is a callback::There are 2 values"
+        )
+
+        # Every JavaClass has a built-in NULL
+        self.assertEqual(
+            obj1.combiner(3, "Pork", Thing.__null__, handler, [1, 2]),
+            '3::Pork::<no special thing>::There is a callback::There are 2 values'
+        )
+
+        # JavaClasses can also be used to construct a null.
+        self.assertEqual(
+            obj1.combiner(3, "Pork", JavaNull(Thing), handler, [1, 2]),
+            '3::Pork::<no special thing>::There is a callback::There are 2 values'
+        )
+
+        # Every JavaInterface has a built-in NULL
+        self.assertEqual(
+            obj1.combiner(3, "Pork", thing, ICallback.__null__, [1, 2]),
+            '3::Pork::This is thing 2::<no callback>::There are 2 values'
+        )
+
+        # JavaInterfaces can also be used to construct a null.
+        self.assertEqual(
+            obj1.combiner(3, "Pork", thing, JavaNull(ICallback), [1, 2]),
+            '3::Pork::This is thing 2::<no callback>::There are 2 values'
+        )
+
+        # Arrays are constructed by passing in a list with a single type item.
+        self.assertEqual(
+            obj1.combiner(3, "Pork", thing, handler, JavaNull([int])),
+            '3::Pork::This is thing 2::There is a callback::<no values to count>'
+        )
+
+        # If NULL arguments don't match available options, an error is raised
         with self.assertRaises(ValueError):
-            obj1.combiner(1.234, "Pork")
+            obj1.combiner(3, "Pork", JavaNull(str), handler, [1, 2]),
+
+    def test_polymorphic_method_null(self):
+        "Polymorphic methods can be passed NULLs"
+        Example = JavaClass('org/beeware/rubicon/test/Example')
+        obj1 = Example()
+
+        self.assertEqual(obj1.doubler(JavaNull(str)), "Can't double NULL strings")
+
+    def test_java_null_construction(self):
+        "Java NULLs can be constructed"
+        Example = JavaClass('org/beeware/rubicon/test/Example')
+        obj1 = Example()
+
+        # Java nulls can be constructed explicitly
+        self.assertEqual(JavaNull(b"Lcom/example/Thing;")._signature, b"Lcom/example/Thing;")
+
+        # Java nulls can be constructed from a JavaClass
+        self.assertEqual(JavaNull(Example)._signature, b"Lorg/beeware/rubicon/test/Example;")
+
+        # Java nulls can be constructed from an instance
+        self.assertEqual(JavaNull(obj1)._signature, b"Lorg/beeware/rubicon/test/Example;")
+
+        # A Java Null can be constructed for Python or JNI primitives
+        self.assertEqual(JavaNull(int)._signature, b"I")
+        self.assertEqual(JavaNull(jlong)._signature, b"J")
+        self.assertEqual(JavaNull(str)._signature, b"Ljava/lang/String;")
+        self.assertEqual(JavaNull(jstring)._signature, b"Ljava/lang/String;")
+
+        # Bytes is converted directly to an array of byte
+        self.assertEqual(JavaNull(bytes)._signature, b"[B")
+
+        # Some types can't be converted
+        with self.assertRaises(ValueError):
+            JavaNull(None)
+
+        # A Java Null for an array of primitives can be defined with a list
+        # of Python or JNI primitives
+        self.assertEqual(JavaNull([int])._signature, b"[I")
+        self.assertEqual(JavaNull([jlong])._signature, b"[J")
+
+        # A Java Null for an array of objects can be defined with a list
+        self.assertEqual(JavaNull([Example])._signature, b"[Lorg/beeware/rubicon/test/Example;")
+
+        # A Java Null for an array of explicit JNI references
+        self.assertEqual(JavaNull([b'Lcom/example/Thing;'])._signature, b"[Lcom/example/Thing;")
+
+        # Arrays are defined with a type, not a literal
+        with self.assertRaises(ValueError):
+            JavaNull([1])
+
+        # Arrays must have a single element
+        with self.assertRaises(ValueError):
+            JavaNull([])
+
+        # Arrays can *only* have a single element
+        with self.assertRaises(ValueError):
+            JavaNull([int, int])
+
+        # Some types can't be converted in a list
+        with self.assertRaises(ValueError):
+            JavaNull([None])
 
     def test_polymorphic_static_method(self):
         "Check that the right static method is activated based on arguments used"


### PR DESCRIPTION
Many Java APIs allow the user to pass `null` as an argument. However, as we need to do dynamic lookup of methods by type, a `None` argument can't be easily matches to a specific type.

This change allows the user to pass in `None` as an argument to methods where an object is expected. 

If there are multiple polymorphic forms that *could* accept None, an error is raised. There is an edge case where this is legal - a class with `mymethod(BaseClass x)` and `mymethod(SubClass x)` will be use the SubClass version if passed a `None` . This case raises an error at present.

The implementation also changes the key used to look up polymorphs. Previously it was the JNI signature; we now use a tuple composed of the signature's parts. This should be no slower for lookup; but allows us to do wildcard matching on the JNI signature parts.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
