### PR TITLE
Fixes #58 - Allow casting Java objects to other types

### DIFF
--- a/changes/58.feature.rst
+++ b/changes/58.feature.rst
@@ -1,0 +1,1 @@
+Added the ability to cast Java objects from one class to another.

--- a/org/beeware/rubicon/test/Example.java
+++ b/org/beeware/rubicon/test/Example.java
@@ -137,6 +137,10 @@ public class Example extends BaseExample {
         return theThing;
     }
 
+    public Object get_generic_thing() {
+        return theThing;
+    }
+
     /* String argument/return value handling */
     public String duplicate_string(String in) {
         return in + in;

--- a/org/beeware/rubicon/test/Thing.java
+++ b/org/beeware/rubicon/test/Thing.java
@@ -7,16 +7,23 @@ public class Thing {
     static public int static_int_field = 11;
 
     static public String name;
+    int count;
 
     public Thing(String n) {
         name = n;
+        count = -1;
     }
 
-    public Thing(String n, int count) {
-        name = n + ' ' + count;
+    public Thing(String n, int c) {
+        count = c;
+        name = n + ' ' + c;
     }
 
     public String toString() {
         return name;
+    }
+
+    public int currentCount() {
+        return count;
     }
 }

--- a/rubicon/java/api.py
+++ b/rubicon/java/api.py
@@ -1141,6 +1141,7 @@ class JavaClass(type):
             cast = self(__jni__=obj.__jni__)
         return cast
 
+
 ###########################################################################
 # Representations of Java classes and instances
 ###########################################################################

--- a/rubicon/java/api.py
+++ b/rubicon/java/api.py
@@ -476,9 +476,9 @@ class StaticJavaMethod(object):
         except KeyError as e:
             raise ValueError(
                 "Can't find Java static method '%s.%s' matching argument signature '%s'. Options are: %s" % (
-                    self.java_class.__dict__['_descriptor'],
+                    self.java_class.__dict__['_descriptor'].decode('utf-8'),
                     self.name,
-                    e,
+                    e.args[0].decode('utf-8'),
                     ', '.join(
                         signature_for_type_names(type_names).decode('utf-8')
                         for type_names in self._polymorphs.keys()
@@ -537,9 +537,9 @@ class JavaMethod:
         except KeyError as e:
             raise ValueError(
                 "Can't find Java instance method '%s.%s' matching argument signature '%s'. Options are: %s" % (
-                    self.java_class.__dict__['_descriptor'],
+                    self.java_class.__dict__['_descriptor'].decode('utf-8'),
                     self.name,
-                    e,
+                    e.args[0].decode('utf-8'),
                     ', '.join(
                         signature_for_type_names(type_names).decode('utf-8')
                         for type_names in self._polymorphs.keys()
@@ -833,7 +833,7 @@ class JavaInstance(object):
             except KeyError as e:
                 raise ValueError(
                     "Can't find constructor matching argument signature %s. Options are: %s" % (
-                        e,
+                        e.args[0].decode('utf-8'),
                         ', '.join(
                             signature_for_type_names(type_names).decode('utf-8')
                             for type_names in constructors.keys()
@@ -904,6 +904,17 @@ class JavaInstance(object):
             return field_wrapper.set(self, value)
 
         raise AttributeError("'%s' Java object has no attribute '%s'" % (self.__class__.__name__, name))
+
+    def __cast__(self, klass, globalref=False):
+        """Cast the object to a specific class.
+
+        Optionally, make the resulting reference a global JNI reference.
+        """
+        if globalref:
+            cast = klass(__jni__=java.NewGlobalRef(self))
+        else:
+            cast = klass(__jni__=self.__jni__)
+        return cast
 
 
 class UnknownClassException(Exception):

--- a/rubicon/java/api.py
+++ b/rubicon/java/api.py
@@ -871,17 +871,6 @@ class JavaInstance(object):
 
         raise AttributeError("'%s' Java object has no attribute '%s'" % (self.__class__.__name__, name))
 
-    def __cast__(self, klass, globalref=False):
-        """Cast the object to a specific class.
-
-        Optionally, make the resulting reference a global JNI reference.
-        """
-        if globalref:
-            cast = klass(__jni__=java.NewGlobalRef(self))
-        else:
-            cast = klass(__jni__=self.__jni__)
-        return cast
-
 
 class UnknownClassException(Exception):
     def __init__(self, descriptor):
@@ -1141,6 +1130,16 @@ class JavaClass(type):
     def __repr__(self):
         return "<JavaClass: %s>" % self._descriptor.decode('utf-8')
 
+    def __cast__(self, obj, globalref=False):
+        """Cast the provided object to this class.
+
+        Optionally, make the resulting reference a global JNI reference.
+        """
+        if globalref:
+            cast = self(__jni__=java.NewGlobalRef(obj))
+        else:
+            cast = self(__jni__=obj.__jni__)
+        return cast
 
 ###########################################################################
 # Representations of Java classes and instances

--- a/tests/test_rubicon.py
+++ b/tests/test_rubicon.py
@@ -265,6 +265,36 @@ class JNITest(TestCase):
         with self.assertRaises(ValueError):
             Example.tripler(1.234)
 
+    def test_type_cast(self):
+        "An object can be cast to another type"
+        Example = JavaClass('org/beeware/rubicon/test/Example')
+        obj1 = Example()
+
+        Thing = JavaClass('org/beeware/rubicon/test/Thing')
+        thing = Thing('This is thing', 2)
+
+        obj1.set_thing(thing)
+
+        # Retrieve a generic reference to the object (java.lang.Object)
+        obj = obj1.get_generic_thing()
+
+        # Attempting to use this generic object *as* a Thing will fail.
+        with self.assertRaises(AttributeError):
+            obj.currentCount()
+        with self.assertRaises(ValueError):
+            obj1.combiner(3, "Ham", obj)
+
+        # ...but if we cast it to the type we know it is
+        # (org.beeware.rubicon.test.Thing), the same calls will succeed.
+        cast_thing = obj.__cast__(Thing)
+        self.assertEqual(cast_thing.currentCount(), 2)
+        self.assertEqual(obj1.combiner(4, "Ham", cast_thing), "4::Ham::This is thing 2")
+
+        # We can also cast as a global JNI reference
+        # (org.beeware.rubicon.test.Thing), the same calls will succeed.
+        global_cast_thing = obj.__cast__(Thing, globalref=True)
+        self.assertEqual(obj1.combiner(4, "Ham", global_cast_thing), "4::Ham::This is thing 2")
+
     def test_pass_int_array(self):
         """A list of Python ints can be passed as a Java int array."""
         Example = JavaClass("org/beeware/rubicon/test/Example")

--- a/tests/test_rubicon.py
+++ b/tests/test_rubicon.py
@@ -386,7 +386,7 @@ class JNITest(TestCase):
 
         # ...but if we cast it to the type we know it is
         # (org.beeware.rubicon.test.Thing), the same calls will succeed.
-        cast_thing = obj.__cast__(Thing)
+        cast_thing = Thing.__cast__(obj)
         self.assertEqual(cast_thing.currentCount(), 2)
         self.assertEqual(
             obj1.combiner(4, "Ham", cast_thing, ICallback_null, JavaNull([int])),
@@ -395,7 +395,7 @@ class JNITest(TestCase):
 
         # We can also cast as a global JNI reference
         # (org.beeware.rubicon.test.Thing), the same calls will succeed.
-        global_cast_thing = obj.__cast__(Thing, globalref=True)
+        global_cast_thing = Thing.__cast__(obj, globalref=True)
         self.assertEqual(
             obj1.combiner(4, "Ham", global_cast_thing, ICallback_null, JavaNull([int])),
             "4::Ham::This is thing 2::<no callback>::<no values to count>"

--- a/tests/test_rubicon.py
+++ b/tests/test_rubicon.py
@@ -376,22 +376,30 @@ class JNITest(TestCase):
         # Retrieve a generic reference to the object (java.lang.Object)
         obj = obj1.get_generic_thing()
 
+        ICallback_null = JavaNull(b'Lorg/beeware/rubicon/test/ICallback;')
+
         # Attempting to use this generic object *as* a Thing will fail.
         with self.assertRaises(AttributeError):
             obj.currentCount()
         with self.assertRaises(ValueError):
-            obj1.combiner(3, "Ham", obj)
+            obj1.combiner(3, "Ham", obj, ICallback_null, JavaNull([int]))
 
         # ...but if we cast it to the type we know it is
         # (org.beeware.rubicon.test.Thing), the same calls will succeed.
         cast_thing = obj.__cast__(Thing)
         self.assertEqual(cast_thing.currentCount(), 2)
-        self.assertEqual(obj1.combiner(4, "Ham", cast_thing), "4::Ham::This is thing 2")
+        self.assertEqual(
+            obj1.combiner(4, "Ham", cast_thing, ICallback_null, JavaNull([int])),
+            "4::Ham::This is thing 2::<no callback>::<no values to count>"
+        )
 
         # We can also cast as a global JNI reference
         # (org.beeware.rubicon.test.Thing), the same calls will succeed.
         global_cast_thing = obj.__cast__(Thing, globalref=True)
-        self.assertEqual(obj1.combiner(4, "Ham", global_cast_thing), "4::Ham::This is thing 2")
+        self.assertEqual(
+            obj1.combiner(4, "Ham", global_cast_thing, ICallback_null, JavaNull([int])),
+            "4::Ham::This is thing 2::<no callback>::<no values to count>"
+        )
 
     def test_pass_int_array(self):
         """A list of Python ints can be passed as a Java int array."""


### PR DESCRIPTION
Allows a Java object reference to be cast to another class using the `__cast__()` 

`obj.__cast__(Thing)` will cast the instance `obj` to the JavaClass `Thing`. 

`obj.__cast__(Thing, globalref=True)` will cast the instance `obj` to the JavaClass `Thing`, and make the resulting object a global JNI reference.

(Note: This PR builds on #63)

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
