### PR TITLE
Fixes #59 - Adds a simple API call to convert local JNI references to global references

### DIFF
--- a/changes/59.feature.rst
+++ b/changes/59.feature.rst
@@ -1,0 +1,1 @@
+Local JNI Instances can be converted into global JNI instances using ``__global__()``

--- a/rubicon/java/api.py
+++ b/rubicon/java/api.py
@@ -905,6 +905,10 @@ class JavaInstance(object):
 
         raise AttributeError("'%s' Java object has no attribute '%s'" % (self.__class__.__name__, name))
 
+    def __global__(self):
+        "Return an global reference to the same object"
+        return self.__class__(__jni__=java.NewGlobalRef(self))
+
     def __cast__(self, klass, globalref=False):
         """Cast the object to a specific class.
 

--- a/tests/test_rubicon.py
+++ b/tests/test_rubicon.py
@@ -295,6 +295,18 @@ class JNITest(TestCase):
         global_cast_thing = obj.__cast__(Thing, globalref=True)
         self.assertEqual(obj1.combiner(4, "Ham", global_cast_thing), "4::Ham::This is thing 2")
 
+    def test_convert_to_global(self):
+        "An object can be converted into a global JNI reference."
+        Example = JavaClass('org/beeware/rubicon/test/Example')
+        obj1 = Example()
+
+        Thing = JavaClass('org/beeware/rubicon/test/Thing')
+        thing = Thing('This is thing', 2)
+
+        global_thing = thing.__global__()
+        self.assertEqual(global_thing.currentCount(), 2)
+        self.assertEqual(obj1.combiner(5, "Spam", global_thing), "5::Spam::This is thing 2")
+
     def test_pass_int_array(self):
         """A list of Python ints can be passed as a Java int array."""
         Example = JavaClass("org/beeware/rubicon/test/Example")


### PR DESCRIPTION
Provides a simple API entry point for converting JNI references from local to global.

`obj.__global__()` will return a global reference to `obj`.

Note: This PR builds on #64.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
