### PR TITLE
Improve typed NULL handling

### DIFF
--- a/changes/67.feature.rst
+++ b/changes/67.feature.rst
@@ -1,0 +1,1 @@
+Methods that return NULL now return typed NULL objects.

--- a/rubicon/java/api.py
+++ b/rubicon/java/api.py
@@ -989,8 +989,8 @@ class JavaNull:
         return "<NULL>"
 
     def __eq__(self, other):
-        # Nulls are always equivalent
-        return self._signature == other._signature
+        # Nulls are always equal to all other nulls
+        return isinstance(other, JavaNull)
 
     def __bool__(self):
         # Nulls are always false

--- a/rubicon/java/api.py
+++ b/rubicon/java/api.py
@@ -328,7 +328,7 @@ def return_cast(raw, return_signature):
         # Check for NULL return values
         if raw.value:
             return JavaClass(return_signature[1:-1].decode('utf-8'))(__jni__=raw)
-        return None
+        return JavaNull(return_signature)
 
     raise ValueError("Don't know how to cast return signature '%s'" % return_signature)
 
@@ -981,6 +981,20 @@ class JavaNull:
                         }[type_or_signature]
                     except KeyError:
                         raise ValueError("Cannot create a typed null for {!r}".format(type_or_signature))
+
+    def __repr__(self):
+        return f"<Java NULL ({self._signature.decode('utf-8')})>"
+
+    def __str__(self):
+        return "<NULL>"
+
+    def __eq__(self, other):
+        # Nulls are always equivalent
+        return self._signature == other._signature
+
+    def __bool__(self):
+        # Nulls are always false
+        return False
 
 
 class JavaClass(type):

--- a/tests/test_rubicon.py
+++ b/tests/test_rubicon.py
@@ -304,12 +304,13 @@ class JNITest(TestCase):
         obj = Example()
 
         Thing = JavaClass('org/beeware/rubicon/test/Thing')
-        thing = Thing('This is thing', 2)
 
         obj.set_thing(Thing.__null__)
         returned = obj.get_thing()
         # Typed null objects are always equal to equivalent typed nulls
         self.assertEqual(returned, Thing.__null__)
+        # All Typed nulls are equivalent
+        self.assertEqual(returned, Example.__null__)
         # Null is always false
         self.assertFalse(returned)
 

--- a/tests/test_rubicon.py
+++ b/tests/test_rubicon.py
@@ -298,6 +298,21 @@ class JNITest(TestCase):
 
         self.assertEqual(obj1.doubler(JavaNull(str)), "Can't double NULL strings")
 
+    def test_null_return(self):
+        "Returned NULL objects are typed"
+        Example = JavaClass('org/beeware/rubicon/test/Example')
+        obj = Example()
+
+        Thing = JavaClass('org/beeware/rubicon/test/Thing')
+        thing = Thing('This is thing', 2)
+
+        obj.set_thing(Thing.__null__)
+        returned = obj.get_thing()
+        # Typed null objects are always equal to equivalent typed nulls
+        self.assertEqual(returned, Thing.__null__)
+        # Null is always false
+        self.assertFalse(returned)
+
     def test_java_null_construction(self):
         "Java NULLs can be constructed"
         Example = JavaClass('org/beeware/rubicon/test/Example')
@@ -351,6 +366,17 @@ class JNITest(TestCase):
         # Some types can't be converted in a list
         with self.assertRaises(ValueError):
             JavaNull([None])
+
+    def test_null_repr(self):
+        "Null objects can be output to console"
+        # Output of a null makes sense
+        self.assertEqual(repr(JavaNull(b'Lcom/example/Thing;')), "<Java NULL (Lcom/example/Thing;)>")
+        self.assertEqual(repr(JavaNull(str)), "<Java NULL (Ljava/lang/String;)>")
+        self.assertEqual(repr(JavaNull(int)), "<Java NULL (I)>")
+
+        self.assertEqual(str(JavaNull(b'Lcom/example/Thing;')), "<NULL>")
+        self.assertEqual(str(JavaNull(str)), "<NULL>")
+        self.assertEqual(str(JavaNull(int)), "<NULL>")
 
     def test_polymorphic_static_method(self):
         "Check that the right static method is activated based on arguments used"


### PR DESCRIPTION
* Return values from methods are converted to typed NULL objects.
* Typed NULL objects evaluate as false, are comparable with other typed nulls, and are printable.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
