### PR TITLE
Support arrays of strings.

### DIFF
--- a/rubicon/java/jni.py
+++ b/rubicon/java/jni.py
@@ -196,6 +196,12 @@ java.NewFloatArray.argtypes = [jsize]
 java.SetFloatArrayRegion.restype = None
 java.SetFloatArrayRegion.argtypes = [jfloatArray, jsize, jsize, jfloat_p]
 
+java.NewObjectArray.restype = jobjectArray
+java.NewObjectArray.argtypes = [jsize, jclass, jobject]
+
+java.SetObjectArrayElement.restype = None
+java.SetObjectArrayElement.argtypes = [jobjectArray, jsize, jobject]
+
 
 class _ReflectionAPI(object):
     "A lazy-loading proxy for the key classes and methods in the Java reflection API"


### PR DESCRIPTION
Background: I'm attempting to request permissions from the user in an Android Toga app.

This requires calling [requestPermissions](https://developer.android.com/reference/androidx/core/app/ActivityCompat#requestPermissions(android.app.Activity,%20java.lang.String[],%20int)) which accepts an array of strings as an argument.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct

Update: now this works:

    from toga_android.libs.activity import MainActivity
    this = MainActivity.singletonThis
    from rubicon.java import JavaClass
    activity_compat = JavaClass('androidx/core/app/ActivityCompat')
    activity_compat.requestPermissions(
        this,
        ['android.permission.CAMERA'],
        0
    )
