### PR TITLE
Fixes #55 - Add support for array types

### DIFF
--- a/changes/55.feature.rst
+++ b/changes/55.feature.rst
@@ -1,0 +1,1 @@
+Added support for arrays in arguments and return values.

--- a/org/beeware/rubicon/test/Example.java
+++ b/org/beeware/rubicon/test/Example.java
@@ -162,6 +162,78 @@ public class Example extends BaseExample {
         return in + in;
     }
 
+    public boolean [] doubler(boolean [] in) {
+        boolean [] out = new boolean[in.length * 2];
+        for (int i = 0; i < out.length; i++) {
+            out[i] = in[i / 2];
+        }
+        return out;
+    }
+
+    public byte [] doubler(byte [] in) {
+        byte [] out = new byte[in.length * 2];
+        for (int i = 0; i < out.length; i++) {
+            out[i] = in[i / 2];
+        }
+        return out;
+    }
+
+    public short [] doubler(short [] in) {
+        short [] out = new short[in.length * 2];
+        for (int i = 0; i < out.length; i++) {
+            out[i] = in[i / 2];
+        }
+        return out;
+    }
+
+    public int [] doubler(int [] in) {
+        int [] out = new int[in.length * 2];
+        for (int i = 0; i < out.length; i++) {
+            out[i] = in[i / 2];
+        }
+        return out;
+    }
+
+    public long [] doubler(long [] in) {
+        long [] out = new long[in.length * 2];
+        for (int i = 0; i < out.length; i++) {
+            out[i] = in[i / 2];
+        }
+        return out;
+    }
+
+    public float [] doubler(float [] in) {
+        float [] out = new float[in.length * 2];
+        for (int i = 0; i < out.length; i++) {
+            out[i] = in[i / 2];
+        }
+        return out;
+    }
+
+    public double [] doubler(double [] in) {
+        double [] out = new double[in.length * 2];
+        for (int i = 0; i < out.length; i++) {
+            out[i] = in[i / 2];
+        }
+        return out;
+    }
+
+    public String [] doubler(String [] in) {
+        String [] out = new String[in.length * 2];
+        for (int i = 0; i < out.length; i++) {
+            out[i] = in[i / 2];
+        }
+        return out;
+    }
+
+    public Thing [] doubler(Thing [] in) {
+        Thing [] out = new Thing[in.length * 2];
+        for (int i = 0; i < out.length; i++) {
+            out[i] = in[i / 2];
+        }
+        return out;
+    }
+
     public static String tripler(String in) {
         return in + in + in;
     }

--- a/org/beeware/rubicon/test/Thing.java
+++ b/org/beeware/rubicon/test/Thing.java
@@ -6,8 +6,8 @@ import org.beeware.rubicon.Python;
 public class Thing {
     static public int static_int_field = 11;
 
-    static public String name;
-    int count;
+    public String name;
+    public int count;
 
     public Thing(String n) {
         name = n;

--- a/rubicon/java/jni.py
+++ b/rubicon/java/jni.py
@@ -5,8 +5,8 @@ from .types import (
     jarray, jboolean, jboolean_p, jbooleanArray,
     jbyte, jbyte_p, jbyteArray, jchar, jclass,
     jdouble, jdouble_p, jdoubleArray, jfieldID, jfloat, jfloat_p, jfloatArray,
-    jint, jint_p, jintArray, jlong, jmethodID, jobject, jobjectArray,
-    jshort, jsize, jstring,
+    jint, jint_p, jintArray, jlong, jlong_p, jlongArray, jmethodID, jobject, jobjectArray,
+    jshort, jshort_p, jshortArray, jsize, jstring,
 )
 
 # If RUBICON_LIBRARY is set in the environment, rely on it. If not,
@@ -163,38 +163,62 @@ java.GetStringUTFChars.argtypes = [jstring, jboolean_p]
 
 java.GetArrayLength.restype = jsize
 java.GetArrayLength.argtypes = [jarray]
+
+java.NewObjectArray.restype = jobjectArray
+java.NewObjectArray.argtypes = [jsize, jclass, jobject]
 java.GetObjectArrayElement.restype = jobject
 java.GetObjectArrayElement.argtypes = [jobjectArray, jsize]
+java.SetObjectArrayElement.restype = None
+java.SetObjectArrayElement.argtypes = [jobjectArray, jsize, jobject]
 
 java.NewByteArray.restype = jbyteArray
 java.NewByteArray.argtypes = [jsize]
-
 java.SetByteArrayRegion.restype = None
 java.SetByteArrayRegion.argtypes = [jbyteArray, jsize, jsize, jbyte_p]
+java.GetByteArrayElements.restype = jbyte_p
+java.GetByteArrayElements.argtypes = [jbyteArray, jboolean_p]
 
 java.NewBooleanArray.restype = jbooleanArray
 java.NewBooleanArray.argtypes = [jsize]
-
 java.SetBooleanArrayRegion.restype = None
 java.SetBooleanArrayRegion.argtypes = [jbooleanArray, jsize, jsize, jboolean_p]
+java.GetBooleanArrayElements.restype = jboolean_p
+java.GetBooleanArrayElements.argtypes = [jbooleanArray, jboolean_p]
 
 java.NewDoubleArray.restype = jdoubleArray
 java.NewDoubleArray.argtypes = [jsize]
-
 java.SetDoubleArrayRegion.restype = None
 java.SetDoubleArrayRegion.argtypes = [jdoubleArray, jsize, jsize, jdouble_p]
+java.GetDoubleArrayElements.restype = jdouble_p
+java.GetDoubleArrayElements.argtypes = [jdoubleArray, jboolean_p]
+
+java.NewShortArray.restype = jshortArray
+java.NewShortArray.argtypes = [jsize]
+java.SetShortArrayRegion.restype = None
+java.SetShortArrayRegion.argtypes = [jshortArray, jsize, jsize, jshort_p]
+java.GetShortArrayElements.restype = jshort_p
+java.GetShortArrayElements.argtypes = [jshortArray, jboolean_p]
 
 java.NewIntArray.restype = jintArray
 java.NewIntArray.argtypes = [jsize]
-
 java.SetIntArrayRegion.restype = None
 java.SetIntArrayRegion.argtypes = [jintArray, jsize, jsize, jint_p]
+java.GetIntArrayElements.restype = jint_p
+java.GetIntArrayElements.argtypes = [jintArray, jboolean_p]
+
+java.NewLongArray.restype = jlongArray
+java.NewLongArray.argtypes = [jsize]
+java.SetLongArrayRegion.restype = None
+java.SetLongArrayRegion.argtypes = [jlongArray, jsize, jsize, jlong_p]
+java.GetLongArrayElements.restype = jlong_p
+java.GetLongArrayElements.argtypes = [jlongArray, jboolean_p]
 
 java.NewFloatArray.restype = jfloatArray
 java.NewFloatArray.argtypes = [jsize]
-
 java.SetFloatArrayRegion.restype = None
 java.SetFloatArrayRegion.argtypes = [jfloatArray, jsize, jsize, jfloat_p]
+java.GetFloatArrayElements.restype = jfloat_p
+java.GetFloatArrayElements.argtypes = [jfloatArray, jboolean_p]
 
 
 class _ReflectionAPI(object):

--- a/rubicon/java/types.py
+++ b/rubicon/java/types.py
@@ -1,6 +1,6 @@
 from ctypes import (
-    POINTER, Structure, c_bool, c_byte, c_char_p, c_double, c_float, c_int32,
-    c_longlong, c_short, c_void_p, c_wchar,
+    POINTER, Structure, c_bool, c_byte, c_char_p, c_double, c_float, c_int16,
+    c_int32, c_int64, c_void_p, c_wchar,
 )
 
 __all__ = [
@@ -18,9 +18,9 @@ __all__ = [
 jboolean = c_bool
 jbyte = c_byte
 jchar = c_wchar
-jshort = c_short
+jshort = c_int16
 jint = c_int32
-jlong = c_longlong
+jlong = c_int64
 jfloat = c_float
 jdouble = c_double
 

--- a/tests/test_rubicon.py
+++ b/tests/test_rubicon.py
@@ -2,7 +2,7 @@ import math
 import sys
 from unittest import TestCase
 
-from rubicon.java import JavaClass, JavaInterface, JavaNull, jstring, jlong
+from rubicon.java import JavaClass, JavaInterface, JavaNull, jdouble, jfloat, jstring, jlong, jshort, jint
 
 
 class JNITest(TestCase):
@@ -225,6 +225,62 @@ class JNITest(TestCase):
         # If arguments don't match available options, an error is raised
         with self.assertRaises(ValueError):
             obj1.doubler(1.234)
+
+    def test_byte_array_arg(self):
+        "Bytestrings can be used as arguments (as byte arrays)"
+        Example = JavaClass('org/beeware/rubicon/test/Example')
+        obj1 = Example()
+
+        self.assertEqual(obj1.doubler(b'abcd'), b'aabbccdd')
+
+    def test_int_array_arg(self):
+        "Arrays of int can be used as arguments"
+        Example = JavaClass('org/beeware/rubicon/test/Example')
+        obj1 = Example()
+        self.assertEqual(obj1.doubler([1, 2]), [1, 1, 2, 2])
+        self.assertEqual(obj1.doubler([jlong(1), jlong(2)]), [1, 1, 2, 2])
+        self.assertEqual(obj1.doubler([jshort(1), jshort(2)]), [1, 1, 2, 2])
+        self.assertEqual(obj1.doubler([jint(1), jint(2)]), [1, 1, 2, 2])
+
+    def assertAlmostEqualList(self, actual, expected):
+        self.assertEqual(len(expected), len(actual), "Lists are different length")
+        for i, (a, e) in enumerate(zip(actual, expected)):
+            self.assertAlmostEqual(a, e)
+
+    def test_float_array_arg(self):
+        "Arrays of float can be used as arguments"
+        Example = JavaClass('org/beeware/rubicon/test/Example')
+        obj1 = Example()
+
+        self.assertAlmostEqualList(obj1.doubler([1.1, 2.2]), [1.1, 1.1, 2.2, 2.2])
+        self.assertAlmostEqualList(obj1.doubler([jfloat(1.1), jfloat(2.2)]), [1.1, 1.1, 2.2, 2.2])
+        self.assertAlmostEqualList(obj1.doubler([jdouble(1.1), jdouble(2.2)]), [1.1, 1.1, 2.2, 2.2])
+
+    def test_bool_array_arg(self):
+        "Arrays of bool can be used as arguments"
+        Example = JavaClass('org/beeware/rubicon/test/Example')
+        obj1 = Example()
+        self.assertEqual(obj1.doubler([True, False]), [True, True, False, False])
+
+    def test_string_array_arg(self):
+        "Arrays of string can be used as arguments"
+        Example = JavaClass('org/beeware/rubicon/test/Example')
+        obj1 = Example()
+        self.assertEqual(obj1.doubler(["one", "two"]), ["one", "one", "two", "two"])
+
+    def test_object_array_arg(self):
+        "Arrays of object can be used as arguments"
+        Example = JavaClass('org/beeware/rubicon/test/Example')
+        obj1 = Example()
+
+        Thing = JavaClass('org/beeware/rubicon/test/Thing')
+        thing1 = Thing('This is one', 1)
+        thing2 = Thing('This is two', 2)
+
+        self.assertEqual(
+            [str(obj) for obj in obj1.doubler([thing1, thing2])],
+            [str(obj) for obj in [thing1, thing1, thing2, thing2]]
+        )
 
     def test_method_null(self):
         "Null objects can be passed as arguments"


### PR DESCRIPTION
Adds support for array types as arguments and as return values. This includes

* All primitive types (int, byte, double etc)
* Strings
* Any Java object type

This won't work on nested arrays, but single-dimensional arrays should work.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
