### PR TITLE
Fixes #32 - Allow for SystemExit.

### DIFF
--- a/changes/32.bugfix.rst
+++ b/changes/32.bugfix.rst
@@ -1,0 +1,1 @@
+When the test suite completes successfully, it no longer outputs a message suggesting failure.

--- a/jni/rubicon.c
+++ b/jni/rubicon.c
@@ -1010,7 +1010,14 @@ JNIEXPORT jint JNICALL Java_org_beeware_rubicon_Python_run(JNIEnv *env, jobject 
     if (!ret) {
         result = PyObject_Call(run_module_as_main, runargs, NULL);
         if (result == NULL) {
-            LOG_E("Application quit abnormally!");
+            if (PyErr_ExceptionMatches(PyExc_SystemExit)) {
+                LOG_D("Python code raised SystemExit");
+            } else {
+                LOG_E("Application quit abnormally!");
+            }
+
+            // In the case of a SystemExit, printing the exception
+            // will terminate the process (including the Java VM).
             PyErr_Print();
             PyErr_Clear();
             ret = 1;


### PR DESCRIPTION
Corrects the "Application Quit abnormally" message when the test suite completes successfully.

Underlying problem is that `tests.runner` raises SystemExit, which is implemented as an exception; so "normal completion" wasn't being differentiated from "problem during execution". 

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
