### PR TITLE
Fixes #72 - Support builds on M1 hardware

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,13 @@ ifeq ($(IS_ANDROID),yes)
 	LDFLAGS := $(LDFLAGS) -llog
 endif
 
+# When compiling on macOS, check for M1/Apple Silicon.
+IS_APPLE_SILICON := $(shell uname -ms | grep -q "Darwin arm64" && echo yes || echo no)
+ifeq ($(IS_APPLE_SILICON),yes)
+	CFLAGS := $(CFLAGS) -arch x86_64
+	LDFLAGS := $(LDFLAGS) -arch x86_64
+endif
+
 ifdef JAVA_HOME
 	JAVAC := $(JAVA_HOME)/bin/javac
 else

--- a/changes/72.bugfix.rst
+++ b/changes/72.bugfix.rst
@@ -1,0 +1,1 @@
+Modified test suite to support M1/Apple Silicon.


### PR DESCRIPTION
Adds flags to ensure that the build is always x86_64, even on M1 hardware. This is needed because Java doesn't yet ship M1 hardware.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
