### PR TITLE
Cleanup of event loop Runnables.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,8 +45,8 @@ jobs:
     name: Smoke test
     strategy:
       matrix:
-        os: [ubuntu-18.04, macos-10.15]
-        python-version: ["3.6"]
+        os: [ubuntu-18.04, macOS-latest]
+        python-version: ["3.7"]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Environment - checkout code
@@ -79,8 +79,8 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
-        os: [ubuntu-18.04, macos-latest]
+        python-version: ["3.8", "3.9", "3.10", "3.11.0-alpha - 3.11.0"]
+        os: [ubuntu-18.04, macOS-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Environment - checkout code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: '3.X'
     - name: Install dependencies
@@ -52,7 +52,7 @@ jobs:
       - name: Environment - checkout code
         uses: actions/checkout@main
       - name: Environment - Setup python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
       - name: Environment - Use Java 8
@@ -86,7 +86,7 @@ jobs:
       - name: Environment - checkout code
         uses: actions/checkout@main
       - name: Environment - Setup python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
       - name: Environment - Use Java 8

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
   pull_request:
     push:
       branches:
-        - master
+        - main
 
 jobs:
   beefore:
@@ -50,7 +50,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Environment - checkout code
-        uses: actions/checkout@master
+        uses: actions/checkout@main
       - name: Environment - Setup python
         uses: actions/setup-python@v1
         with:
@@ -84,7 +84,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Environment - checkout code
-        uses: actions/checkout@master
+        uses: actions/checkout@main
       - name: Environment - Setup python
         uses: actions/setup-python@v1
         with:
@@ -113,7 +113,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Environment - checkout code
-        uses: actions/checkout@master
+        uses: actions/checkout@main
       - name: Install dependencies, compile rubicon-java, and run tests
         uses: docker://i386/ubuntu:18.04
         # This step does everything because changes within the container

--- a/changes/76.bugfix.rst
+++ b/changes/76.bugfix.rst
@@ -1,0 +1,1 @@
+Asynchronous co-routines clean up their handler callbacks when being re-queued. Without this cleanup, every time an co-routine was awaited, a no-op invocation of the handler would occur.

--- a/changes/template.rst
+++ b/changes/template.rst
@@ -1,7 +1,19 @@
+{% if top_line %}
+{{ top_line }}
+{{ top_underline * ((top_line)|length)}}
+{% elif versiondata.name %}
+{{ versiondata.name }} {{ versiondata.version }} ({{ versiondata.date }})
+{{ top_underline * ((versiondata.name + versiondata.version + versiondata.date)|length + 4)}}
+{% else %}
+{{ versiondata.version }} ({{ versiondata.date }})
+{{ top_underline * ((versiondata.version + versiondata.date)|length + 3)}}
+{% endif %}
 {% for section, _ in sections.items() %}
 {% set underline = underlines[0] %}{% if section %}{{section}}
 {{ underline * section|length }}{% set underline = underlines[1] %}
+
 {% endif %}
+
 {% if sections[section] %}
 {% for category, val in definitions.items() if category in sections[section]%}
 {{ definitions[category]['name'] }}
@@ -11,8 +23,10 @@
 {% for text, values in sections[section][category].items() %}
 * {{ text }} ({{ values|join(', ') }})
 {% endfor %}
+
 {% else %}
 * {{ sections[section][category]['']|join(', ') }}
+
 {% endif %}
 {% if sections[section][category]|length == 0 %}
 No significant changes.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,13 @@
+[build-system]
+requires = [
+    "setuptools >= 46.4.0",
+    "wheel >= 0.32.0",
+]
+build-backend = "setuptools.build_meta"
+
 [tool.towncrier]
 directory = "changes"
 package = "rubicon.java"
-package_dir = "."
 filename = "docs/background/releases.rst"
 title_format = "{version} ({project_date})"
 template = "changes/template.rst"

--- a/rubicon/java/android_events.py
+++ b/rubicon/java/android_events.py
@@ -229,17 +229,8 @@ class AndroidInterop:
         # This allows us to avoid creating more than one Java object per Python callable, which
         # would prevent removeCallbacks from working.
         self._runnable_by_fn = {}
-        # _handler is a lazily-created `android.os.Handler`. We use its `postDelayed()` method
-        # to ask for wakeup. We only create it when needed, which avoids using memory & CPU
-        # until needed.
-        self._handler = None
-
-    @property
-    def handler(self):
-        if self._handler is None:
-            # Use the default constructor, which assumes we are on the Android UI thread.
-            self._handler = Handler()
-        return self._handler
+        # The handler must be created on the Android UI thread.
+        self.handler = Handler()
 
     def get_or_create_runnable(self, fn):
         if fn in self._runnable_by_fn:

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,7 +43,7 @@ exclude=
     __pycache__
     build/*
     docs/*
-    venv/*
+    venv*/*
     local/*
 max-complexity = 26
 max-line-length = 119

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = flake8,towncrier-check,docs,package,py{36,37,38,39,310},pypy3
+envlist = flake8,towncrier-check,docs,package,py{36,37,38,39,310,311},pypy3
 skip_missing_interpreters = true
 
 [testenv]
@@ -31,18 +31,13 @@ skip_install = True
 deps =
     {[testenv:towncrier]deps}
 commands =
-    python -m towncrier.check
+    python -m towncrier.check --compare-with origin/main
 
 [testenv:towncrier]
 skip_install = True
 deps =
-    towncrier >= 18.5.0
-setenv =
-    DYLD_LIBRARY_PATH=./build
-whitelist_externals =
-    make
+    towncrier == 21.9.0
 commands =
-    make
     towncrier {posargs}
 
 [testenv:docs]


### PR DESCRIPTION
Every time `call_soon` is called, it adds a Runnable to the Android event queue, which repeatedly re-enqueues itself when it runs. However, `call_soon` is also called internally by the event loop base class as part of processing the coroutine. So this caused each iteration of the couroutine to accumulate one additional Runnable. The actual coroutine was still only executed once: all the other Runnables would find that no tasks were due.

In addition, if the call to `add_background_worker()` was first performed on a thread, the lazy creation of the Handler() object meant that the handler would operate on the child thread, not the GUI thread. This would cause issues with performing GUI operations in any queued worker coroutine.

This is a port of:
- [31b8b6df1c33b1d00f885513541f3ab9a895e709](https://github.com/beeware/briefcase-android-gradle-template/pull/52/commits/31b8b6df1c33b1d00f885513541f3ab9a895e709) 
- [232029aee22bfc255eb47a9ed95569f94cc2bc6c](https://github.com/beeware/briefcase-android-gradle-template/pull/52/commits/232029aee22bfc255eb47a9ed95569f94cc2bc6c)

from beeware/briefcase-android-gradle-template#52, provided by @mhsmith.

Fixes beeware/toga#1539
Fixes beeware/toga#1542

Also includes a bunch of updates to tox, CI and towncrier configs that were preventing CI from passing.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
