### PR TITLE
Updated project setup to use generated Java folder instead of objc fo…

### DIFF
--- a/docs/how-to/contribute-code.rst
+++ b/docs/how-to/contribute-code.rst
@@ -25,7 +25,7 @@ coding:
     (venv) $ python -m pip install --upgrade pip
     (venv) $ python -m pip install --upgrade setuptools
     (venv) $ git clone https://github.com/beeware/rubicon-java.git
-    (venv) $ cd rubicon-objc
+    (venv) $ cd rubicon-java
     (venv) $ python -m pip install -e .
 
 Rubicon uses tox to describe it's testing environment. To install tox, run:


### PR DESCRIPTION
…lder

The how-to guide for rubicon-java had some instructions which pointed to rubicon-objc; I changed it to rubicon-java.


<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x ] I will abide by the code of conduct
