### PR TITLE
Archive project.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,7 @@
+**This project has been archived. It was used by Briefcase 0.3.9 and earlier to
+support Android projects; however, that role is now performed by `Chaquopy
+<https://chqauo.com>`__.**
+
 .. image:: https://beeware.org/project/projects/bridges/rubicon/rubicon.png
     :width: 72px
     :target: https://beeware.org/rubicon

--- a/changes/77.misc.rst
+++ b/changes/77.misc.rst
@@ -1,0 +1,1 @@
+A reference to rubicon-objc was corrected.

--- a/docs/how-to/contribute-code.rst
+++ b/docs/how-to/contribute-code.rst
@@ -25,7 +25,7 @@ coding:
     (venv) $ python -m pip install --upgrade pip
     (venv) $ python -m pip install --upgrade setuptools
     (venv) $ git clone https://github.com/beeware/rubicon-java.git
-    (venv) $ cd rubicon-objc
+    (venv) $ cd rubicon-java
     (venv) $ python -m pip install -e .
 
 Rubicon uses tox to describe it's testing environment. To install tox, run:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -29,6 +29,12 @@
 Rubicon Java
 ============
 
+.. note::
+
+    This project has been archived. It was used by Briefcase 0.3.9 and earlier
+    to support Android projects; however, that role is now performed by
+    `Chaquopy <https://chqauo.com>`__.
+
 Rubicon Java is a bridge between the Java Runtime Environment and Python. It
 enables you to:
 


### PR DESCRIPTION
With the release of Briefcase 0.3.10, we're now using a Chaquopy base, so Rubicon is no longer in active development.

Integrates the changes from #77 to ensure that the decks are cleared.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
